### PR TITLE
Make sure the buf that parse_status_data() get is always null terminated

### DIFF
--- a/lib/yubihsm_winhttp.c
+++ b/lib/yubihsm_winhttp.c
@@ -183,8 +183,10 @@ static void backend_disconnect(yh_backend *connection) {
 }
 
 static yh_rc backend_connect(yh_connector *connector, int timeout) {
-  uint8_t buf[MAX_STR_LEN];
+  uint8_t buf[MAX_STR_LEN + 1];
   yh_rc res = YHR_CONNECTOR_ERROR;
+
+  ZeroMemory(buf, MAX_STR_LEN + 1);
 
   if (timeout == 0) {
     // TODO: what does winhttp do if it gets timeout 0?


### PR DESCRIPTION
parse_status_data() uses strtok_r which requires a null terminated string.

This also mirrors the code in lib/yubihsm_curl.c.

(Found while playing with libfuzzer)