### PR TITLE
Make it possible to generate authkey

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1501,9 +1501,9 @@ int validate_and_call(yubihsm_context *ctx, CommandList l, const char *line) {
   char *argv[64];
   int i = 0;
 
-  char data[1025];
+  char data[4097];
 
-  char arg_data[1025] = {0};
+  char arg_data[4097] = {0};
 
   Command *command = l;
 
@@ -1522,8 +1522,8 @@ int validate_and_call(yubihsm_context *ctx, CommandList l, const char *line) {
 
   CommandFunction *func = NULL;
 
-  if (strlen(line) > 1024) {
-    printf("Command to long\n");
+  if (strlen(line) > 4096) {
+    printf("Command too long\n");
     return 0;
   }
 


### PR DESCRIPTION
 Make it possible to generate authkey specifying all the capabilities in their string form. Here's one example of what does not work with the current master, and that this PR fixes:
```
yubihsm> put authkey 1 0x03 "NEW MAIN AUTHKEY2" 0xffff change-authentication-key,create-otp-aead,decrypt-oaep,decrypt-otp,decrypt-pkcs,delete-asymmetric-key,delete-authentication-key,delete-hmac-key,delete-opaque,delete-otp-aead-key,delete-template,delete-wrap-key,derive-ecdh,export-wrapped,exportable-under-wrap,generate-asymmetric-key,generate-hmac-key,generate-otp-aead-key,generate-wrap-key,get-log-entries,get-opaque,get-option,get-pseudo-random,get-template,import-wrapped,put-asymmetric-key,put-authentication-key,put-mac-key,put-opaque,put-otp-aead-key,put-template,put-wrap-key,randomize-otp-aead,reset-device,rewrap-from-otp-aead-key,rewrap-to-otp-aead-key,set-option,sign-attestation-certificate,sign-ecdsa,sign-eddsa,sign-hmac,sign-pkcs,sign-pss,sign-ssh-certificate,unwrap-data,verify-hmac,wrap-data change-authentication-key,create-otp-aead,decrypt-oaep,decrypt-otp,decrypt-pkcs,delete-asymmetric-key,delete-authentication-key,delete-hmac-key,delete-opaque,delete-otp-aead-key,delete-template,delete-wrap-key,derive-ecdh,export-wrapped,exportable-under-wrap,generate-asymmetric-key,generate-hmac-key,generate-otp-aead-key,generate-wrap-key,get-log-entries,get-opaque,get-option,get-pseudo-random,get-template,import-wrapped,put-asymmetric-key,put-authentication-key,put-mac-key,put-opaque,put-otp-aead-key,put-template,put-wrap-key,randomize-otp-aead,reset-device,rewrap-from-otp-aead-key,rewrap-to-otp-aead-key,set-option,sign-attestation-certificate,sign-ecdsa,sign-eddsa,sign-hmac,sign-pkcs,sign-pss,sign-ssh-certificate,unwrap-data,verify-hmac,wrap-data
Enter password: 
Stored Authentication key 0x0003
```