### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR instead of CMAKE_SOURCE_DIR

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ endif ()
 
 project (yubihsm-shell)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 
 # Set various install paths
 if (NOT DEFINED YUBIHSM_INSTALL_LIB_DIR)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -168,9 +168,9 @@ set (
 
 include_directories (
   ${LIBCRYPTO_INCLUDEDIR}
-  ${CMAKE_SOURCE_DIR}/lib
-  ${CMAKE_SOURCE_DIR}/pkcs11
-  ${CMAKE_SOURCE_DIR}/common
+  ${CMAKE_CURRENT_SOURCE_DIR}/../lib
+  ${CMAKE_CURRENT_SOURCE_DIR}/../pkcs11
+  ${CMAKE_CURRENT_SOURCE_DIR}/../common
   )
 
 configure_file (

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -16,11 +16,11 @@
 
 set (
   SOURCE
-  ${CMAKE_SOURCE_DIR}/aes_cmac/aes.c
-  ${CMAKE_SOURCE_DIR}/aes_cmac/aes_cmac.c
-  ${CMAKE_SOURCE_DIR}/common/hash.c
-  ${CMAKE_SOURCE_DIR}/common/pkcs5.c
-  ${CMAKE_SOURCE_DIR}/common/rand.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/../aes_cmac/aes.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/../aes_cmac/aes_cmac.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/../common/hash.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/../common/pkcs5.c
+  ${CMAKE_CURRENT_SOURCE_DIR}/../common/rand.c
   error.c
   lib_util.c
   yubihsm.c
@@ -82,7 +82,7 @@ else(${WIN32})
 endif(${WIN32})
 
 include_directories (
-  ${CMAKE_SOURCE_DIR}/lib
+  ${CMAKE_CURRENT_SOURCE_DIR}
   ${LIBCRYPTO_INCLUDEDIR}
 )
 

--- a/lib/tests/CMakeLists.txt
+++ b/lib/tests/CMakeLists.txt
@@ -45,7 +45,7 @@ set (
   )
 
 include_directories (
-  ${CMAKE_SOURCE_DIR}/lib
+  ${CMAKE_CURRENT_SOURCE_DIR}/../lib
   )
 
 add_executable (test_parsing ${SOURCE_PARSING})

--- a/pkcs11/CMakeLists.txt
+++ b/pkcs11/CMakeLists.txt
@@ -29,8 +29,8 @@ set(
   )
 
 include_directories(
-  ${CMAKE_SOURCE_DIR}/lib
-  ${CMAKE_SOURCE_DIR}/pkcs11
+  ${CMAKE_CURRENT_SOURCE_DIR}/../lib
+  ${CMAKE_CURRENT_SOURCE_DIR}
   ${LIBCRYPTO_INCLUDEDIR}
   )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,10 +35,10 @@ endif()
 
 include_directories (
   ${LIBCRYPTO_INCLUDEDIR}
-  ${CMAKE_SOURCE_DIR}/lib
-  ${CMAKE_SOURCE_DIR}/src
-  ${CMAKE_SOURCE_DIR}/common
-  ${CMAKE_SOURCE_DIR}/ykyh
+  ${CMAKE_CURRENT_SOURCE_DIR}/../lib
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/../common
+  ${CMAKE_CURRENT_SOURCE_DIR}/../ykyh
   )
 
 if(${WIN32})

--- a/yhauth/CMakeLists.txt
+++ b/yhauth/CMakeLists.txt
@@ -29,8 +29,8 @@ message("${GGO_C}")
 
 include_directories (
   ${LIBCRYPTO_INCLUDEDIR}
-  ${CMAKE_SOURCE_DIR}/ykyh
-  ${CMAKE_SOURCE_DIR}/common
+  ${CMAKE_CURRENT_SOURCE_DIR}/../ykyh
+  ${CMAKE_CURRENT_SOURCE_DIR}/../common
 )
 
 if (CMAKE_C_COMPILER_ID MATCHES Clang)

--- a/yhwrap/CMakeLists.txt
+++ b/yhwrap/CMakeLists.txt
@@ -34,8 +34,8 @@ message("${GGO_C}")
 
 include_directories (
   ${LIBCRYPTO_INCLUDEDIR}
-  ${CMAKE_SOURCE_DIR}/lib
-  ${CMAKE_SOURCE_DIR}/common
+  ${CMAKE_CURRENT_SOURCE_DIR}/../lib
+  ${CMAKE_CURRENT_SOURCE_DIR}/../common
 )
 
 if(${WIN32})


### PR DESCRIPTION
Using CMAKE_CURRENT_SOURCE_DIR allows this project to be included in other cmake projects where CMAKE_SOURCE_DIR may not be what is expected here

I didn't change a few targets like `dist` (because not really interesting from a cmake reuse standpoint) and `cppcheck` (because I don't have a good way of checking it at the moment) so there might be other fine tuning that still could be done to improve the CMAKE_SOURCE_DIR vs CMAKE_CURRENT_SOURCE_DIR