### PR TITLE
Add a library only build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ endif ()
 
 project (yubihsm-shell)
 
+option(BUILD_ONLY_LIB "Library only build" OFF)
+
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 
 # Set various install paths
@@ -155,28 +157,33 @@ else()
 
   find_package (PkgConfig REQUIRED)
   pkg_search_module (LIBCRYPTO REQUIRED libcrypto)
-  pkg_search_module (LIBEDIT REQUIRED libedit)
+  if(NOT BUILD_ONLY_LIB)
+    pkg_search_module (LIBEDIT REQUIRED libedit)
+  endif()
   pkg_search_module (LIBCURL REQUIRED libcurl)
   pkg_search_module (LIBUSB REQUIRED libusb-1.0)
 endif()
 
 add_subdirectory (lib)
-add_subdirectory (pkcs11)
 
-if (ENABLE_EXPERIMENTAL_YKYH)
-  pkg_search_module (LIBPCSC REQUIRED libpcsclite)
-  add_subdirectory (ykyh)
+if(NOT BUILD_ONLY_LIB)
+  add_subdirectory (pkcs11)
+
+  if (ENABLE_EXPERIMENTAL_YKYH)
+    pkg_search_module (LIBPCSC REQUIRED libpcsclite)
+    add_subdirectory (ykyh)
+  endif()
+
+  add_subdirectory (src)
+
+  add_subdirectory (examples)
+
+  if (ENABLE_EXPERIMENTAL_YKYH)
+    add_subdirectory (yhauth)
+  endif()
+
+  add_subdirectory(yhwrap)
 endif()
-
-add_subdirectory (src)
-
-add_subdirectory (examples)
-
-if (ENABLE_EXPERIMENTAL_YKYH)
-  add_subdirectory (yhauth)
-endif()
-
-add_subdirectory(yhwrap)
 
 add_custom_target (
   cppcheck


### PR DESCRIPTION
When integrating the yubihsm-shell repository in to other cmake projects oftentimes only the yubihsm library is required. However, the CMakeLists.txt will bring in a number of dependencies needed for the various tools, such as libedit, help2man, gengetopt, etc., that are unneeded for just building the library.

Add a cmake option to enable a library only build so that these additional dependencies are not required by cmake when a parent cmake project just wants to link against libyubihsm.