### PR TITLE
Windows x86 build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,9 +121,12 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
   if ("${CMAKE_SIZEOF_VOID_P}" EQUAL "8")
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,--high-entropy-va")
     set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wl,--image-base -Wl,0x140000000")
+    # mingw64 gcc with -pie puts the entry address in the wrong place, help it..
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-emainCRTStartup")
+  else()
+    # mingw32 gcc with -pie puts the entry address in the wrong place, with a different symbol than mingw64, help it..
+    set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-e_mainCRTStartup")
   endif ()
-  # gcc with -pie puts the entry adress in the wrong spot, help it..
-  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,-emainCRTStartup")
   add_definitions (-D_POSIX_THREAD_SAFE_FUNCTIONS=1)
   add_definitions (-D__USE_MINGW_ANSI_STDIO=1)
   add_definitions (-DWIN32_LEAN_AND_MEAN=1)

--- a/aes_cmac/aes.c
+++ b/aes_cmac/aes.c
@@ -19,6 +19,7 @@
 
 #include <string.h>
 #include <assert.h>
+#include <stdlib.h>
 
 #ifdef _WIN32_BCRYPT
 #include <ntstatus.h>

--- a/common/hash.c
+++ b/common/hash.c
@@ -21,6 +21,8 @@
 #include <openssl/evp.h>
 #endif
 
+#include <stdlib.h>
+
 #include "hash.h"
 #include "insecure_memzero.h"
 

--- a/src/main.c
+++ b/src/main.c
@@ -709,7 +709,7 @@ static bool probe_session(yubihsm_context *ctx, int index) {
 }
 
 #ifdef __WIN32
-static void timer_handler(void *lpParam __attribute__((unused)),
+static void WINAPI timer_handler(void *lpParam __attribute__((unused)),
                           unsigned char TimerOrWaitFired
                           __attribute__((unused))) {
 #else


### PR DESCRIPTION
build: fix 32-bit Windows builds with mingw32/gcc7
shell: apply stdcall calling convention for Windows callback on x86