### PR TITLE
tool: stop the timer for keepalive while we do EVP_read_pw_string()

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1324,10 +1324,28 @@ static bool get_input_data(const char *name, uint8_t *out, size_t *len,
       return false;
     }
     if (file == stdin && fmt == fmt_password) {
+#ifndef __WIN32
+      // NOTE: we have to stop the timer around the call to
+      // EVP_read_pw_string(), openssl gets sad if a signal hits while waiting
+      // for input from the user. So we stop the timer and restore it when we're
+      // done
+      struct itimerval stoptimer, oldtimer;
+      memset(&stoptimer, 0, sizeof(stoptimer));
+      if (setitimer(ITIMER_REAL, &stoptimer, &oldtimer) != 0) {
+        fprintf(stderr, "Failed to setup timer\n");
+        return false;
+      }
+#endif
       if (EVP_read_pw_string((char *) out, *len, "Enter password: ", 0) == 0) {
         data_len = strlen((char *) out);
         ret = true;
       }
+#ifndef __WIN32
+      if (setitimer(ITIMER_REAL, &oldtimer, NULL) != 0) {
+        fprintf(stderr, "Failed to restore timer\n");
+        return false;
+      }
+#endif
     } else if (read_file(file, out, &data_len)) {
       ret = true;
     }
@@ -1622,8 +1640,10 @@ int validate_and_call(yubihsm_context *ctx, CommandList l, const char *line) {
   }
 
   if (found == true) {
+    calling_device = true;
     func(ctx, arguments,
          ctx->out_fmt == fmt_nofmt ? command->out_fmt : ctx->out_fmt);
+    calling_device = false;
 
     for (int i = 0; i < n_arguments; i++) {
       if (arguments[i].x != NULL) {
@@ -2685,9 +2705,7 @@ int main(int argc, char *argv[]) {
 #ifndef __WIN32
         history(g_hist, &ev, H_ENTER, buf);
 #endif
-        calling_device = true;
         validate_and_call(&ctx, g_commands, buf);
-        calling_device = false;
       }
     }
 


### PR DESCRIPTION
openssl gets sad if a signal hits while that function is waiting for
input from the user and will both be interrupted and the actual input
will be dumped on the prompt.

Also move the blocking of keepalive further into when we actually make a
call to the device rather than being around the whole collection and
validation logic.