### PR TITLE
switch wrap_id and object_id of args of yh_com_get_wrapped

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -2148,11 +2148,11 @@ int main(int argc, char *argv[]) {
             break;
           }
 
-          arg[1].w = args_info.object_id_arg;
+          arg[1].w = args_info.wrap_id_arg;
           yrc = yh_string_to_type(args_info.object_type_arg, &arg[2].t);
           LIB_SUCCEED_OR_DIE(yrc, "Unable to parse type: ");
 
-          arg[3].w = args_info.wrap_id_arg;
+          arg[3].w = args_info.object_id_arg;
 
           arg[4].s = args_info.out_arg;
           arg[4].len = strlen(args_info.out_arg);


### PR DESCRIPTION
Hi, 
I found a bug of yubihsm-wrap command.
I think wrap_id and object_id of args of yh_com_get_wrapped is switched.

https://github.com/Yubico/yubihsm-shell/blob/master/src/main.c#L2138-L2164
https://github.com/Yubico/yubihsm-shell/blob/master/src/commands.c#L1008-L1026
https://github.com/Yubico/yubihsm-shell/blob/master/lib/yubihsm.h#L1557-L1559