### PR TITLE
Fix tests on FreeBSD.

### DIFF
--- a/pkcs11/tests/CMakeLists.txt
+++ b/pkcs11/tests/CMakeLists.txt
@@ -213,6 +213,8 @@ message(STATUS "Using PKCS11_TESTER: $ENV{PKCS11TEST_PATH}/pkcs11test")
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set(LIBEXT "dylib")
+elseif (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  set(LIBEXT "so")
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   set(LIBEXT "so")
 elseif (${CMAKE_SYSTEM_NAME} MATCHES "Windows")

--- a/pkcs11/tests/engine_tests.sh
+++ b/pkcs11/tests/engine_tests.sh
@@ -24,6 +24,14 @@ os=`uname`
 if [ "x$os" = "xDarwin" ]; then
   echo "mac os not supported yet"
   exit 0
+elif [ "x$os" = "xFreeBSD" ]; then
+  if [ -f "/usr/local/lib/engines/pkcs11.so" ]; then
+    engine="/usr/local/lib/engines/pkcs11.so"
+  else
+    echo "No engine found"
+    exit 0
+  fi
+  ssl_cnf="/etc/ssl/openssl.cnf"
 elif [ "x$os" = "xLinux" ]; then
   if [ -f "/usr/lib/ssl/engines/libpkcs11.so" ]; then
     engine="/usr/lib/ssl/engines/libpkcs11.so"

--- a/src/tests/tests.sh
+++ b/src/tests/tests.sh
@@ -29,13 +29,18 @@ if [ -z ${DEFAULT_CONNECTOR_URL} ]; then
   DEFAULT_CONNECTOR_URL="http://127.0.0.1:12345"
 fi
 PROG="../yubihsm-shell --connector=${DEFAULT_CONNECTOR_URL}"
+if [ "x$(uname)" = "xFreeBSD" ]; then
+  DECODE="b64decode -pr"
+else
+  DECODE="base64 --decode"
+fi
 
 echo "Hello World!" >"$DATA"
 OUTPUT=$($PROG -a generate-asymmetric -A ecp256 -csign-ecdsa -p password 2>&1)
 OBJ_ID=$(echo "$OUTPUT" | grep -o -E '0x[a-f0-9]{4}$')
 
 $PROG -a sign-ecdsa -i $OBJ_ID -A ecdsa-sha256 --in "$DATA" --out "$SIG" -p password
-base64 --decode "$SIG" >"$BIN_SIG"
+$DECODE "$SIG" >"$BIN_SIG"
 $PROG -a get-public-key -i $OBJ_ID --out "$PUBLIC_KEY" -p password
 openssl dgst -sha256 -verify "$PUBLIC_KEY" -signature "$BIN_SIG" "$DATA"
 
@@ -43,7 +48,7 @@ truncate -s 0 "$SIG"
 truncate -s 0 "$PUBLIC_KEY"
 #$PROG -a generate-asymmetric -i 0x1234 -A ecp256 -csign_ecdsa
 $PROG -a sign-ecdsa -i $OBJ_ID -A ecdsa-sha1 --in "$DATA" --out "$SIG" -p password
-base64 --decode "$SIG" >"$BIN_SIG"
+$DECODE "$SIG" >"$BIN_SIG"
 $PROG -a get-public-key -i $OBJ_ID --out "$PUBLIC_KEY" -p password
 openssl dgst -sha1 -verify "$PUBLIC_KEY" -signature "$BIN_SIG" "$DATA"
 
@@ -52,7 +57,7 @@ truncate -s 0 "$PUBLIC_KEY"
 OUTPUT=$($PROG -a generate-asymmetric -A ecp384 -csign-ecdsa -p password 2>&1)
 OBJ_ID=$(echo "$OUTPUT" | grep -o -E '0x[a-f0-9]{4}$')
 $PROG -a sign-ecdsa -i $OBJ_ID -A ecdsa-sha384 --in "$DATA" --out "$SIG" -p password
-base64 --decode "$SIG" >"$BIN_SIG"
+$DECODE "$SIG" >"$BIN_SIG"
 $PROG -a get-public-key -i $OBJ_ID --out "$PUBLIC_KEY" -p password
 openssl dgst -sha384 -verify "$PUBLIC_KEY" -signature "$BIN_SIG" "$DATA"
 
@@ -61,7 +66,7 @@ truncate -s 0 "$PUBLIC_KEY"
 OUTPUT=$($PROG -a generate-asymmetric -A ecp521 -csign-ecdsa -p password 2>&1)
 OBJ_ID=$(echo "$OUTPUT" | grep -o -E '0x[a-f0-9]{4}$')
 $PROG -a sign-ecdsa -i $OBJ_ID -A ecdsa-sha512 --in "$DATA" --out "$SIG" -p password
-base64 --decode "$SIG" >"$BIN_SIG"
+$DECODE "$SIG" >"$BIN_SIG"
 $PROG -a get-public-key -i $OBJ_ID --out "$PUBLIC_KEY" -p password
 openssl dgst -sha512 -verify "$PUBLIC_KEY" -signature "$BIN_SIG" "$DATA"
 


### PR DESCRIPTION
#51 fixed build on FreeBSD but it did not fix tests.  After this patch, all tests passed.

```
[0/1] Running tests...
Test project /tmp/yubihsm-shell-master/build
      Start  1: parsing
 1/25 Test  #1: parsing ..........................   Passed    0.00 sec
      Start  2: pbkdf2
 2/25 Test  #2: pbkdf2 ...........................   Passed    0.02 sec
      Start  3: attest
 3/25 Test  #3: attest ...........................   Passed    0.44 sec
      Start  4: generate_ec
 4/25 Test  #4: generate_ec ......................   Passed    0.30 sec
      Start  5: generate_hmac
 5/25 Test  #5: generate_hmac ....................   Passed    0.19 sec
      Start  6: import_authkey
 6/25 Test  #6: import_authkey ...................   Passed    0.22 sec
      Start  7: import_rsa
 7/25 Test  #7: import_rsa .......................   Passed    0.36 sec
      Start  8: info
 8/25 Test  #8: info .............................   Passed    0.08 sec
      Start  9: wrap
 9/25 Test  #9: wrap .............................   Passed    0.36 sec
      Start 10: wrap_data
10/25 Test #10: wrap_data ........................   Passed    0.18 sec
      Start 11: yubico_otp
11/25 Test #11: yubico_otp .......................   Passed    0.42 sec
      Start 12: echo
12/25 Test #12: echo .............................   Passed    0.14 sec
      Start 13: import_ec
13/25 Test #13: import_ec ........................   Passed    0.30 sec
      Start 14: generate_rsa
14/25 Test #14: generate_rsa .....................   Passed    3.55 sec
      Start 15: logs
15/25 Test #15: logs .............................   Passed    0.27 sec
      Start 16: ssh
16/25 Test #16: ssh ..............................   Passed    0.42 sec
      Start 17: decrypt_rsa
17/25 Test #17: decrypt_rsa ......................   Passed    0.51 sec
      Start 18: decrypt_ec
18/25 Test #18: decrypt_ec .......................   Passed    0.30 sec
      Start 19: import_ed
19/25 Test #19: import_ed ........................   Passed    0.34 sec
      Start 20: change_authkey
20/25 Test #20: change_authkey ...................   Passed    0.35 sec
      Start 21: engine_tests
21/25 Test #21: engine_tests .....................   Passed   16.21 sec
      Start 22: pkcs11test
22/25 Test #22: pkcs11test .......................   Passed  108.77 sec
      Start 23: ecdh_derive_test
23/25 Test #23: ecdh_derive_test .................   Passed    2.46 sec
      Start 24: bash_tests
24/25 Test #24: bash_tests .......................   Passed    2.88 sec
      Start 25: wrapped_tests
25/25 Test #25: wrapped_tests ....................   Passed   10.65 sec

100% tests passed, 0 tests failed out of 25

Total Test time (real) = 149.75 sec
```