### PR TITLE
build: mingw/gcc 9.2.0 has broken FORTIFY_SOURCE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,9 @@ set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format-zero-length -Wno-implicit-fallt
 set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wformat -Wformat-security")
 
 # fortify can only be used with -O2 and higher, so only enable for release builds
-set (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -D_FORTIFY_SOURCE=2")
+if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  set (CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -D_FORTIFY_SOURCE=2")
+endif ()
 if (NOT DISABLE_LTO)
   if (CMAKE_C_COMPILER_ID STREQUAL GNU)
     if (CMAKE_C_COMPILER_VERSION VERSION_GREATER 6.0)


### PR DESCRIPTION
Setting FORTIFY_SOURCE in the latest mingw gcc breaks our build and requires that we take an unnecessary dynamic dependency.  It never had much effect before, so it has been removed for Windows builds.