### PR TITLE
Increase size of CLI work buffer

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1826,7 +1826,7 @@ int main(int argc, char *argv[]) {
 #endif
 
   if (args_info.action_given) {
-    uint8_t buf[4096] = {0};
+    uint8_t buf[8192] = {0};
 
     ctx.out = open_file(args_info.out_arg, false);
     if (ctx.out == NULL) {


### PR DESCRIPTION
At least, wrapped keys, with metadata and base64, can easily be > 4096
bytes (5016 for a wrapped RSA:4096 object I have here).

I think for reading files a growable heap buffer makes more sense, but
this is a cheap hack to get me running again.