### PR TITLE
Avoid warnings with some gcc versions

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1170,7 +1170,7 @@ unsigned char yubihsm_complete(EditLine *el, int ch) {
 
   const LineInfo *li;
 
-  int argc, cursorc, cursoro;
+  int argc, cursorc = 0, cursoro = 0;
   char *argv[64];
   char data[ARGS_BUFFER_SIZE + 1] = {0};
 


### PR DESCRIPTION
The error I was getting during the builds for Fedora rawhide:

```
/builddir/build/BUILD/yubihsm-shell-2.0.2/src/main.c: In function 'yubihsm_complete':
/builddir/build/BUILD/yubihsm-shell-2.0.2/src/main.c:1277:16: error: 'cursoro' may be used uninitialized in this function [-Werror=maybe-uninitialized]
 1277 |         return complete_arg(el, args, argv[i], cursoro);
      |                ^
/builddir/build/BUILD/yubihsm-shell-2.0.2/src/main.c:1173:22: note: 'cursoro' was declared here
 1173 |   int argc, cursorc, cursoro;
      |                      ^
lto1: all warnings being treated as errors
```
(but probably because of some different flags, only on s390x architecture)