### PR TITLE
Set the CMP0042 policy to make dotnet able to load yubihsm-pkcs11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ if (CMAKE_VERSION VERSION_GREATER 3.0.0)
   # policy CMP0025 is to get AppleClang identifier rather than Clang for both
   # this matters since the apple compiler accepts different flags.
   cmake_policy(SET CMP0025 NEW)
+  cmake_policy(SET CMP0042 NEW)
 endif ()
 
 project (yubihsm-shell)


### PR DESCRIPTION
dotnet core cannot load our yubihsm-pkcs11.dylib on MacOS Catalina 10.15.5, even though other tools like pkcs11-tool can. This commit fixes that problem. We had the same issue when porting libykcs11.dylib over to cmake. It seems to be a recent problem, earlier testing with dotnet has worked.