### PR TITLE
lib: add a session identifier for the backend

### DIFF
--- a/lib/internal.h
+++ b/lib/internal.h
@@ -67,7 +67,8 @@ struct backend_functions {
   yh_backend *(*backend_create)(void);
   yh_rc (*backend_connect)(yh_connector *connector, int timeout);
   void (*backend_disconnect)(yh_backend *connection);
-  yh_rc (*backend_send_msg)(yh_backend *connection, Msg *msg, Msg *response);
+  yh_rc (*backend_send_msg)(yh_backend *connection, Msg *msg, Msg *response,
+                            const char *identifier);
   void (*backend_cleanup)(void);
   yh_rc (*backend_option)(yh_backend *connection, yh_connector_option opt,
                           const void *val);

--- a/lib/scp.h
+++ b/lib/scp.h
@@ -72,6 +72,7 @@ typedef struct {
   uint8_t s_rmac[SCP_KEY_LEN];
   uint8_t mac_chaining_value[SCP_PRF_LEN];
   uint8_t ctr[SCP_PRF_LEN];
+  char identifier[17];
   bool in_use;
   bool authenticated;
 } Scp_ctx;

--- a/lib/yubihsm_usb.c
+++ b/lib/yubihsm_usb.c
@@ -70,11 +70,14 @@ static void backend_disconnect(yh_backend *connection) {
   usb_destroy(&connection);
 }
 
-static yh_rc backend_send_msg(yh_backend *connection, Msg *msg, Msg *response) {
+static yh_rc backend_send_msg(yh_backend *connection, Msg *msg, Msg *response,
+                              const char *identifier) {
   int32_t trf_len = msg->st.len + 3;
   yh_rc ret = YHR_GENERIC_ERROR;
   unsigned long read_len;
   msg->st.len = htons(msg->st.len);
+
+  (void) identifier;
 
   for (int i = 0; i <= 1; i++) {
     if (ret != YHR_GENERIC_ERROR) {


### PR DESCRIPTION
this allows an http load balancer to keep track of what requests belong
together and need to be stickied on a connector and what can go to a new
one