### PR TITLE
lib: explicitly parse serial as base 10

### DIFF
--- a/lib/lib_util.c
+++ b/lib/lib_util.c
@@ -153,7 +153,7 @@ bool parse_usb_url(const char *url, unsigned long *serial) {
         str += strlen("serial=");
 
         errno = 0;
-        *serial = strtoul(str, &endptr, 0);
+        *serial = strtoul(str, &endptr, 10);
         if ((errno == ERANGE && *serial == ULONG_MAX) || endptr == str ||
             (errno != 0 && *serial == 0)) {
           *serial = 0;

--- a/lib/tests/test_usb_url.c
+++ b/lib/tests/test_usb_url.c
@@ -37,6 +37,8 @@ static void test_urls(void) {
     {"", 0, false},
     {"yhusb://", 0, true},
     {"yhusb://foo=bar&serial=1000000", 1000000, true},
+    {"yhusb://serial=0001234", 1234, true},
+    {"yhusb://serial=0x1234", 0, true},
   };
 
   for (size_t i = 0; i < sizeof(tests) / sizeof(tests[0]); i++) {


### PR DESCRIPTION
Note: that this might break existing scripts since this changes behaviour.
Note 2: there are other strtoul() in this file still parsing with the
        old behaviour, i.e. allowing 0x and 0 prefix for hex and octal.

Fixes #89