### PR TITLE
actions: go back to suppressing the nullable warnings on macos

### DIFF
--- a/.github/workflows/macos_build.yml
+++ b/.github/workflows/macos_build.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install prerequisites
         run: |
           set -x
-          brew install cmake gengetopt help2man libedit libusb openssl@1.1 pcsc-lite pkg-config swig truncate curl
+          brew install cmake gengetopt help2man libedit libusb openssl@1.1 pcsc-lite pkg-config swig truncate
 
       - name: Build and install
         run: |
@@ -24,6 +24,6 @@ jobs:
 
           mkdir build
           pushd "build" &>/dev/null
-            cmake .. -DRELEASE_BUILD=1 -DWITHOUT_YKYH=1 -DWITHOUT_MANPAGES=1
-            make
+            cmake .. -DRELEASE_BUILD=1 -DWITHOUT_MANPAGES=1
+            make VERBOSE=1
           popd &>/dev/null

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ endif ()
 
 if (CMAKE_C_COMPILER_ID STREQUAL AppleClang)
   set (CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -fPIE")
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -isystem /usr/include -Wno-nullability-completeness -Wno-expansion-to-defined")
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-nullability-completeness -Wno-nullability-extension -Wno-expansion-to-defined")
 else()
   # -Wl,--strip-all is dependent on linker not compiler...
   set (CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -Wl,--strip-all -fPIE -pie")
@@ -193,8 +193,7 @@ else()
       pkg_search_module (LIBEDIT REQUIRED libedit)
     endif()
   endif()
-  #pkg_search_module (LIBCURL REQUIRED libcurl)
-  set (LIBCURL_LDFLAGS "-lcurl")
+  pkg_search_module (LIBCURL REQUIRED libcurl)
   pkg_search_module (LIBUSB REQUIRED libusb-1.0)
 endif()
 


### PR DESCRIPTION
actions: go back to suppressing the nullable warnings on macos

This way we can build with both system curl and brew curl

(also removed -DWITHOUT_YKYH=1 since it did not exist as a cmake variable)
