### PR TITLE
common: move hex_decode() to parsing.c and remove parse_hex()

### DIFF
--- a/common/parsing.h
+++ b/common/parsing.h
@@ -19,6 +19,7 @@
 
 #include <stdbool.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include "../common/platform-config.h"
 
 // NOTE(adma): those utility functions do not link against libyubihsm
@@ -35,5 +36,6 @@ enum input_visibility { VISIBLE, HIDDEN_CHECKED, HIDDEN_UNCHECKED };
 bool YH_INTERNAL read_string(const char *name, char *str_buf,
                              size_t str_buf_len,
                              enum input_visibility visibility);
+bool YH_INTERNAL hex_decode(const char *in, uint8_t *out, size_t *len);
 
 #endif

--- a/common/util.c
+++ b/common/util.c
@@ -15,9 +15,7 @@
  */
 
 #include <ctype.h>
-#include <errno.h>
 #include <string.h>
-#include <limits.h>
 
 #include <openssl/bio.h>
 #include <openssl/evp.h>
@@ -557,41 +555,6 @@ bool base64_decode(const char *in, uint8_t *out, size_t *len) {
   }
 }
 
-bool hex_decode(const char *in, uint8_t *out, size_t *len) {
-  int pos = 0;
-  size_t in_len = strlen(in);
-  if (in_len > 0 && in[in_len - 1] == '\n') {
-    in_len--;
-  }
-  if (in_len > 0 && in[in_len - 1] == '\r') {
-    in_len--;
-  }
-  if (in_len % 2 != 0) {
-    return false;
-  } else if (in_len / 2 > *len) {
-    return false;
-  }
-
-  for (size_t i = 0; i < in_len / 2; i++) {
-    char *endptr = NULL;
-    char buf[3] = {0};
-    long num;
-    errno = 0;
-
-    buf[0] = in[pos];
-    buf[1] = in[pos + 1];
-    num = strtol((const char *) buf, &endptr, 16);
-    if ((errno == ERANGE && (num < 0 || num > UCHAR_MAX)) ||
-        (errno != 0 && num == 0) || *endptr != '\0') {
-      return false;
-    }
-    out[i] = (uint8_t) num;
-    pos += 2;
-  }
-  *len = in_len / 2;
-  return true;
-}
-
 bool write_file(const uint8_t *buf, size_t buf_len, FILE *fp, format_t format) {
 
   const uint8_t *p = buf;
@@ -744,30 +707,4 @@ bool split_hmac_key(yh_algorithm algorithm, uint8_t *in, size_t in_len,
   *out_len = 2 * block_size;
 
   return true;
-}
-
-size_t parse_hex(const char *hex, size_t hex_len, uint8_t *parsed) {
-
-  size_t j = 0;
-
-  for (size_t i = 0; i < hex_len; i += 2) {
-    if (isxdigit(hex[i]) == 0 || isxdigit(hex[i + 1]) == 0) {
-      break;
-    }
-
-    if (isdigit(hex[i])) {
-      parsed[j] = (hex[i] - '0') << 4;
-    } else {
-      parsed[j] = (tolower(hex[i]) - 'a' + 10) << 4;
-    }
-
-    if (isdigit(hex[i + 1])) {
-      parsed[j] |= (hex[i + 1] - '0');
-    } else {
-      parsed[j] |= (tolower(hex[i + 1]) - 'a' + 10);
-    }
-
-    j++;
-  }
-  return j;
 }

--- a/common/util.h
+++ b/common/util.h
@@ -57,11 +57,8 @@ bool YH_INTERNAL write_ed25519_key(uint8_t *buf, size_t buf_len, FILE *fp,
                                    format_t format);
 
 bool YH_INTERNAL base64_decode(const char *in, uint8_t *out, size_t *len);
-bool YH_INTERNAL hex_decode(const char *in, uint8_t *out, size_t *len);
 
 bool YH_INTERNAL split_hmac_key(yh_algorithm algorithm, uint8_t *in,
                                 size_t in_len, uint8_t *out, size_t *out_len);
-
-size_t YH_INTERNAL parse_hex(const char *hex, size_t hex_len, uint8_t *parsed);
 
 #endif

--- a/pkcs11/CMakeLists.txt
+++ b/pkcs11/CMakeLists.txt
@@ -21,6 +21,7 @@ set(
   SOURCE
   ../common/hash.c
   ../common/util.c
+  ../common/parsing.c
   ../common/openssl-compat.c
   util_pkcs11.c
   yubihsm_pkcs11.c

--- a/src/main.c
+++ b/src/main.c
@@ -28,6 +28,7 @@
 #include <sys/types.h>
 
 #include "util.h"
+#include "parsing.h"
 #include "commands.h"
 
 #include <openssl/evp.h>
@@ -1799,7 +1800,8 @@ static int parse_configured_pubkeys(yubihsm_context *ctx, char **pubkeys,
 
   for (int i = 0; i < n_pubkeys; i++) {
     uint8_t pk[80];
-    size_t pk_len = parse_hex(pubkeys[i], 2 * sizeof(pk), pk);
+    size_t pk_len = sizeof(pk);
+    hex_decode(pubkeys[i], pk, &pk_len);
     if (pk_len == YH_EC_P256_PUBKEY_LEN) {
       ctx->device_pubkey_list[i] = malloc(pk_len);
     }

--- a/yhauth/main.c
+++ b/yhauth/main.c
@@ -29,41 +29,6 @@
 
 #include "cmdline.h"
 
-static bool hex_decode(const char *hex_in, size_t in_len, uint8_t *hex_out,
-                       size_t *out_len) {
-  const char hex_translate[] = "0123456789abcdef";
-  bool first = true;
-
-  if (*out_len < in_len / 2) {
-    fprintf(stderr, "Unable to decode hex, buffer too small\n");
-    return false;
-  } else if (in_len % 2 != 0) {
-    fprintf(stderr, "Unable to decode hex, wrong length\n");
-    return false;
-  }
-
-  *out_len = in_len / 2;
-  for (size_t i = 0; i < in_len; i++) {
-    char *ind_ptr = strchr(hex_translate, tolower(*hex_in++));
-    int index = 0;
-    if (ind_ptr) {
-      index = ind_ptr - hex_translate;
-    } else {
-      fprintf(stderr, "Unable to decode hex, invalid character\n");
-      return false;
-    }
-
-    if (first) {
-      *hex_out = index << 4;
-    } else {
-      *hex_out++ |= index;
-    }
-    first = !first;
-  }
-
-  return true;
-}
-
 static bool parse_name(const char *prompt, char *name, char *parsed,
                        size_t *parsed_len) {
   if (strlen(name) > *parsed_len) {
@@ -124,7 +89,7 @@ static bool parse_key(const char *prompt, char *key, uint8_t *parsed,
     buf_size = strlen(key);
   }
 
-  if (hex_decode(buf, buf_size, parsed, parsed_len) == false) {
+  if (hex_decode(buf, parsed, parsed_len) == false) {
     return false;
   }
 
@@ -157,7 +122,7 @@ static bool parse_context(const char *prompt, char *context, uint8_t *parsed,
     buf_size = strlen(context);
   }
 
-  if (hex_decode(buf, buf_size, parsed, parsed_len) == false) {
+  if (hex_decode(buf, parsed, parsed_len) == false) {
     return false;
   }
 


### PR DESCRIPTION
parse_hex() and hex_decode() both implement a hex decoder, we had an
additional hex_decode() in yhauth as well that also gets removed and use
the one in common.