### PR TITLE
Additional curl options

### DIFF
--- a/lib/yubihsm.h
+++ b/lib/yubihsm.h
@@ -524,6 +524,9 @@ typedef enum {
   /// File with client certificates key (const char *).
   /// Not implemented on Windows
   YH_CONNECTOR_HTTPS_KEY = 4,
+  /// Comma separated list of hosts ignoring proxy, `*` to disable proxy.
+  /// Not implemented on Windows
+  YH_CONNECTOR_NOPROXY = 5,
 } yh_connector_option;
 
 #pragma pack(push, 1)

--- a/lib/yubihsm.h
+++ b/lib/yubihsm.h
@@ -518,6 +518,12 @@ typedef enum {
   /// Proxy server to use for connecting to the connector (const char *). Not
   /// implemented on Windows
   YH_CONNECTOR_PROXY_SERVER = 2,
+  /// File with client certificate to authenticate client with (const char *).
+  /// Not implemented on Windows
+  YH_CONNECTOR_HTTPS_CERT = 3,
+  /// File with client certificates key (const char *).
+  /// Not implemented on Windows
+  YH_CONNECTOR_HTTPS_KEY = 4,
 } yh_connector_option;
 
 #pragma pack(push, 1)

--- a/lib/yubihsm_curl.c
+++ b/lib/yubihsm_curl.c
@@ -227,6 +227,14 @@ static yh_rc backend_option(yh_backend *connection, yh_connector_option opt,
       option = CURLOPT_CAINFO;
       optname = "CURLOPT_CAINFO";
       break;
+    case YH_CONNECTOR_HTTPS_CERT:
+      option = CURLOPT_SSLCERT;
+      optname = "CURLOPT_SSLCERT";
+      break;
+    case YH_CONNECTOR_HTTPS_KEY:
+      option = CURLOPT_SSLKEY;
+      optname = "CURLOPT_SSLKEY";
+      break;
     case YH_CONNECTOR_PROXY_SERVER:
       option = CURLOPT_PROXY;
       optname = "CURLOPT_PROXY";

--- a/lib/yubihsm_curl.c
+++ b/lib/yubihsm_curl.c
@@ -239,6 +239,10 @@ static yh_rc backend_option(yh_backend *connection, yh_connector_option opt,
       option = CURLOPT_PROXY;
       optname = "CURLOPT_PROXY";
       break;
+    case YH_CONNECTOR_NOPROXY:
+      option = CURLOPT_NOPROXY;
+      optname = "CURLOPT_NOPROXY";
+      break;
     default:
       DBG_ERR("%d is an unknown option", opt);
       return YHR_INVALID_PARAMETERS;

--- a/pkcs11/cmdline.ggo
+++ b/pkcs11/cmdline.ggo
@@ -24,6 +24,7 @@ option "cacert" - "Cacert to use for HTTPS validation" string optional
 option "cert" - "HTTPS client certificate to authenticate with" string optional
 option "key" - "HTTPS client certificate key" string optional
 option "proxy" - "Proxy server to use for connector" string optional
+option "noproxy" - "Comma separated list of hosts ignore proxy for" string optional
 option "timeout" - "Timeout to use for initial connection to connector" int optional default="5"
 option "device-pubkey" - "List of device public keys allowed for asymmetric authentication" string optional multiple
 

--- a/pkcs11/cmdline.ggo
+++ b/pkcs11/cmdline.ggo
@@ -21,6 +21,8 @@ option "dinout" - "Enable pkcs11 function tracing" flag off
 option "libdebug" - "Enable libyubihsm debugging" flag off
 option "debug-file" - "Output file for debugging" string optional default="stderr"
 option "cacert" - "Cacert to use for HTTPS validation" string optional
+option "cert" - "HTTPS client certificate to authenticate with" string optional
+option "key" - "HTTPS client certificate key" string optional
 option "proxy" - "Proxy server to use for connector" string optional
 option "timeout" - "Timeout to use for initial connection to connector" int optional default="5"
 option "device-pubkey" - "List of device public keys allowed for asymmetric authentication" string optional multiple

--- a/pkcs11/yubihsm_pkcs11.c
+++ b/pkcs11/yubihsm_pkcs11.c
@@ -275,6 +275,20 @@ CK_DEFINE_FUNCTION(CK_RV, C_Initialize)(CK_VOID_PTR pInitArgs) {
         goto c_i_failure;
       }
     }
+    if (args_info.cert_given) {
+      if (yh_set_connector_option(connector_list[i], YH_CONNECTOR_HTTPS_CERT,
+                                  args_info.cert_arg) != YHR_SUCCESS) {
+        DBG_ERR("Failed to set HTTPS cert option");
+        goto c_i_failure;
+      }
+    }
+    if (args_info.key_given) {
+      if (yh_set_connector_option(connector_list[i], YH_CONNECTOR_HTTPS_KEY,
+                                  args_info.key_arg) != YHR_SUCCESS) {
+        DBG_ERR("Failed to set HTTPS key option");
+	goto c_i_failure;
+      }
+    }
     if (args_info.proxy_given) {
       if (yh_set_connector_option(connector_list[i], YH_CONNECTOR_PROXY_SERVER,
                                   args_info.proxy_arg) != YHR_SUCCESS) {

--- a/pkcs11/yubihsm_pkcs11.c
+++ b/pkcs11/yubihsm_pkcs11.c
@@ -296,6 +296,13 @@ CK_DEFINE_FUNCTION(CK_RV, C_Initialize)(CK_VOID_PTR pInitArgs) {
         goto c_i_failure;
       }
     }
+    if (args_info.noproxy_given) {
+      if (yh_set_connector_option(connector_list[i], YH_CONNECTOR_NOPROXY,
+                                  args_info.noproxy_arg) != YHR_SUCCESS) {
+        DBG_ERR("Failed to set noproxy option");
+	goto c_i_failure;
+      }
+    }
 
     if (yh_connect(connector_list[i], args_info.timeout_arg) != YHR_SUCCESS) {
       DBG_ERR("Failed to connect '%s'", args_info.connector_arg[i]);


### PR DESCRIPTION
Add support for libcurl cert and key to use client-side certificates as authentication.
Add support for shell like variable expansion.
Add libcurl noproxy option.