### PR TITLE
Use LoadLibraryEx

### DIFF
--- a/lib/yubihsm.c
+++ b/lib/yubihsm.c
@@ -3969,12 +3969,12 @@ static yh_rc load_backend(const char *name, void **backend,
   }
   char path[1024];
   if (!GetModuleFileNameA(module, path, sizeof(path))) {
-    DBG_ERR("Failed getting module name");
+    DBG_ERR("Failed getting module path for 'libyubihsm'");
     return YHR_GENERIC_ERROR;
   }
   char *p = strrchr(path, '\\');
   if (!p) {
-    DBG_ERR("Path separator not found in '%s'", path);
+    DBG_ERR("Path separator not found in module path '%s'", path);
     return YHR_GENERIC_ERROR;
   }
   p[1] = 0;

--- a/lib/yubihsm.c
+++ b/lib/yubihsm.c
@@ -3962,13 +3962,13 @@ static yh_rc load_backend(const char *name, void **backend,
                           struct backend_functions **bf) {
   struct backend_functions *(*backend_functions)(void);
 #ifdef WIN32
-  HMODULE module = GetModuleHandleA("libyubihsm");
+  HMODULE module = GetModuleHandle("libyubihsm");
   if (!module) {
     DBG_ERR("Failed getting module handle for 'libyubihsm'");
     return YHR_GENERIC_ERROR;
   }
   char path[1024];
-  if (!GetModuleFileNameA(module, path, sizeof(path))) {
+  if (!GetModuleFileName(module, path, sizeof(path))) {
     DBG_ERR("Failed getting module path for 'libyubihsm'");
     return YHR_GENERIC_ERROR;
   }

--- a/lib/yubihsm.c
+++ b/lib/yubihsm.c
@@ -3978,7 +3978,7 @@ static yh_rc load_backend(const char *name, void **backend,
     return YHR_GENERIC_ERROR;
   }
   p[1] = 0;
-  strcat(path, name);
+  strcat_s(path, sizeof(path), name);
   DBG_INFO("Loading backend library '%s'", path);
 
   *backend = LoadLibraryEx(path, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);

--- a/lib/yubihsm.c
+++ b/lib/yubihsm.c
@@ -3962,7 +3962,7 @@ static yh_rc load_backend(const char *name, void **backend,
                           struct backend_functions **bf) {
   struct backend_functions *(*backend_functions)(void);
 #ifdef WIN32
-  *backend = LoadLibrary(name);
+  *backend = LoadLibraryEx(name, NULL, LOAD_WITH_ALTERED_SEARCH_PATH);
   if (*backend == NULL) {
     DBG_ERR("Failed loading library '%s'", name);
     return YHR_GENERIC_ERROR;

--- a/lib/yubihsm.c
+++ b/lib/yubihsm.c
@@ -3987,8 +3987,8 @@ static yh_rc load_backend(const char *name, void **backend,
     DBG_ERR("Failed loading backend library '%s'", path);
     return YHR_GENERIC_ERROR;
   }
-  backend_functions = (struct backend_functions * (*) (void) )(
-    (void (*)(void)) GetProcAddress(*backend, "backend_functions"));
+  backend_functions = (struct backend_functions * (*) (void) )
+    GetProcAddress(*backend, "backend_functions");
 #else
   *backend = dlopen(name, RTLD_NOW);
   if (*backend == NULL) {


### PR DESCRIPTION
On Windows, load the backend using LoadLibraryEx with an absolute path derived from the path to libyubihsm and LOAD_WITH_ALTERED_SEARCH_PATH. This allows libyubihsm to find the backend DLL without having to set PATH, even in scenarios where it was loaded indirectly via dynamic loading of yubihsm_pkcs11, for example.