### PR TITLE
Fix command completion for default format

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -864,10 +864,6 @@ int yh_com_set_informat(yubihsm_context *ctx, Argument *argv, cmd_format in_fmt,
   UNUSED(in_fmt);
   UNUSED(fmt);
 
-  if (strcasecmp(argv[0].s, "default") == 0) {
-    g_in_fmt = fmt_nofmt;
-    return 0;
-  }
   for (size_t i = 0; i < sizeof(formats) / sizeof(formats[0]); i++) {
     if (strcasecmp(argv[0].s, formats[i].name) == 0) {
       g_in_fmt = formats[i].format;
@@ -884,10 +880,6 @@ int yh_com_set_outformat(yubihsm_context *ctx, Argument *argv,
   UNUSED(in_fmt);
   UNUSED(fmt);
 
-  if (strcasecmp(argv[0].s, "default") == 0) {
-    g_out_fmt = fmt_nofmt;
-    return 0;
-  }
   for (size_t i = 0; i < sizeof(formats) / sizeof(formats[0]); i++) {
     if (strcasecmp(argv[0].s, formats[i].name) == 0) {
       if (formats[i].format == fmt_password) {

--- a/src/yubihsm-shell.h
+++ b/src/yubihsm-shell.h
@@ -41,8 +41,9 @@ static const struct {
   const char *name;
   cmd_format format;
 } formats[] = {
-  {"base64", fmt_base64}, {"binary", fmt_binary},     {"hex", fmt_hex},
-  {"PEM", fmt_PEM},       {"password", fmt_password}, {"ASCII", fmt_ASCII},
+  {"default", fmt_nofmt}, {"base64", fmt_base64}, {"binary", fmt_binary},
+  {"hex", fmt_hex},       {"PEM", fmt_PEM},       {"password", fmt_password},
+  {"ASCII", fmt_ASCII},
 };
 
 typedef struct {


### PR DESCRIPTION
Command completion for 'set informat' and 'set outformat' for the default option. It could only be typed in manually before.