### PR TITLE
shell: do not index array out of bounds

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1483,10 +1483,10 @@ static bool get_input_data(const char *name, uint8_t *out, size_t *len,
       break;
     case fmt_password:
       // If the password was read from a file, strip off \r\n
-      if (out[data_len - 1] == '\n') {
+      if (data_len > 0 && out[data_len - 1] == '\n') {
         data_len--;
       }
-      if (out[data_len - 1] == '\r') {
+      if (data_len > 0 && out[data_len - 1] == '\r') {
         data_len--;
       }
       out[data_len] = '\0';


### PR DESCRIPTION
Fixes a segfault when pressing enter at the Enter password prompt:

yubihsm> session open 1
Enter password:

Program received signal SIGSEGV, Segmentation fault.
get_input_data (name=0x7f7ffffbbad5 "-", out=0xb7d69f67000 "", len=0x7f7ffffbdd08, fmt=fmt_password)
    at /user/kode/yubihsm-shell/src/main.c:1488
1488          if (out[data_len - 1] == '\n') {
Current language:  auto; currently minimal
(gdb) p data_len
$1 = 0
(gdb)