### PR TITLE
PKCS11: Add encryption flag to CKM_RSA_PKCS mechanism

### DIFF
--- a/pkcs11/util_pkcs11.c
+++ b/pkcs11/util_pkcs11.c
@@ -334,7 +334,7 @@ bool get_mechanism_info(yubihsm_pkcs11_slot *slot, CK_MECHANISM_TYPE type,
   pInfo->flags = 0;
   switch (type) {
     case CKM_RSA_PKCS:
-      pInfo->flags = CKF_DECRYPT | CKA_ENCRYPT;
+      pInfo->flags = CKF_DECRYPT | CKF_ENCRYPT;
 
     case CKM_SHA1_RSA_PKCS:
     case CKM_SHA256_RSA_PKCS:

--- a/pkcs11/util_pkcs11.c
+++ b/pkcs11/util_pkcs11.c
@@ -334,7 +334,7 @@ bool get_mechanism_info(yubihsm_pkcs11_slot *slot, CK_MECHANISM_TYPE type,
   pInfo->flags = 0;
   switch (type) {
     case CKM_RSA_PKCS:
-      pInfo->flags = CKF_DECRYPT;
+      pInfo->flags = CKF_DECRYPT | CKA_ENCRYPT;
 
     case CKM_SHA1_RSA_PKCS:
     case CKM_SHA256_RSA_PKCS:


### PR DESCRIPTION
From Java 9, SunPKCS11 provider disables keys that do not support CKF_ENCRYPT  for legacy reasons. Adding this flag to the decryption mechanism is required for the key to be used to decryption