### PR TITLE
debian fix changelog trailer lines

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,19 +2,19 @@ yubihsm-shell (2.3.0-1) unstable; urgency=medium
 
   * 2.3.0 release
 
- -- Aveen Ismail <aveen.ismail@yubico.com> Wed, 24 Nov 2021 19:28:09 +0100
+ -- Aveen Ismail <aveen.ismail@yubico.com>  Wed, 24 Nov 2021 19:28:09 +0100
 
 yubihsm-shell (2.1.0-1) unstable; urgency=medium
 
   * 2.1.0 release
 
- -- Aveen Ismail <aveen.ismail@yubico.com> Mon, 1 Mar 2021 16:28:03 +0100
+ -- Aveen Ismail <aveen.ismail@yubico.com>  Mon, 1 Mar 2021 16:28:03 +0100
 
 yubihsm-shell (2.0.3-1) unstable; urgency=medium
 
   * 2.0.3 release
 
- -- Aveen Ismail <aveen.ismail@yubico.com> Tue, 13 Oct 2020 13:37:10 +0100
+ -- Aveen Ismail <aveen.ismail@yubico.com>  Tue, 13 Oct 2020 13:37:10 +0100
 
 yubihsm-shell (2.0.2-1) unstable; urgency=medium
 


### PR DESCRIPTION
Fixes:
```
 dpkg-gencontrol: warning:     debian/changelog(l5): badly formatted trailer line
 LINE:  -- Aveen Ismail <aveen.ismail@yubico.com> Mon, 1 Mar 2021 16:28:03 +0100

 dpkg-genbuildinfo: warning:     debian/changelog(l11): badly formatted trailer line
 LINE:  -- Aveen Ismail <aveen.ismail@yubico.com> Tue, 13 Oct 2020 13:37:10 +0100
```