### PR TITLE
Don't use absolute path for cppcheck

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ endif()
 add_custom_target (
   cppcheck
   COMMENT "Running cppcheck"
-  COMMAND /usr/bin/cppcheck
+  COMMAND cppcheck
   --enable=warning,style,unusedFunction,missingInclude
   --template="[{severity}][{id}] {message} {callstack} \(On {file}:{line}\)"
   -i ${CMAKE_SOURCE_DIR}/src/cmdline.c

--- a/cmake/cppcheck.cmake
+++ b/cmake/cppcheck.cmake
@@ -32,7 +32,7 @@ macro (add_cppcheck_target _cc_target _cc_directories _cc_ignore)
 
   add_custom_target (
     ${_cc_target}
-    COMMAND /usr/bin/cppcheck
+    COMMAND cppcheck
     --enable=all
     --template="[{severity}][{id}] {message} {callstack} \(On {file}:{line}\)"
     --suppress="unusedStructMember"


### PR DESCRIPTION
Fix for https://github.com/Yubico/yubihsm-shell/issues/220