### PR TITLE
pkcs11: consolidate common test functions

### DIFF
--- a/examples/p11_generate_rsa.c
+++ b/examples/p11_generate_rsa.c
@@ -110,8 +110,13 @@ int main(int argc, char *argv[]) {
   rv = p11->C_Logout(session);
   assert(rv == CKR_OK);
 
+  rv = p11->C_CloseSession(session);
+  assert(rv == CKR_OK);
+
   rv = p11->C_Finalize(NULL);
   assert(rv == CKR_OK);
+
+  dlclose(handle);
 
   return 0;
 }

--- a/pkcs11/tests/CMakeLists.txt
+++ b/pkcs11/tests/CMakeLists.txt
@@ -238,11 +238,13 @@ set_property(
 set (
   SOURCE_ECDH_DERIVE
   ecdh_derive_test.c
+  common.c
   )
 
 set (
   SOURCE_RSA_ENC_TEST
   rsa_enc_test.c
+  common.c
   )
 
 if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Windows")

--- a/pkcs11/tests/common.c
+++ b/pkcs11/tests/common.c
@@ -25,11 +25,20 @@
 
 #include "common.h"
 
-CK_FUNCTION_LIST_PTR get_function_list(char *argv[]) {
-  void *handle = dlopen(argv[1], RTLD_NOW | RTLD_GLOBAL);
+void *open_module(const char *path) {
+  void *handle = dlopen(path, RTLD_NOW | RTLD_GLOBAL);
   assert(handle != NULL);
-  CK_C_GetFunctionList fn;
+  return handle;
+}
 
+void close_module(void *handle) {
+  assert(handle != NULL);
+  int r = dlclose(handle);
+  assert(r == 0);
+}
+
+CK_FUNCTION_LIST_PTR get_function_list(void *handle) {
+  CK_C_GetFunctionList fn;
   *(void **) (&fn) = dlsym(handle, "C_GetFunctionList");
   assert(fn != NULL);
 

--- a/pkcs11/tests/common.c
+++ b/pkcs11/tests/common.c
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2021 Yubico AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifdef NDEBUG
+#undef NDEBUG
+#endif
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <dlfcn.h>
+
+#include "common.h"
+
+CK_FUNCTION_LIST_PTR get_function_list(char *argv[]) {
+  void *handle = dlopen(argv[1], RTLD_NOW | RTLD_GLOBAL);
+  assert(handle != NULL);
+  CK_C_GetFunctionList fn;
+
+  *(void **) (&fn) = dlsym(handle, "C_GetFunctionList");
+  assert(fn != NULL);
+
+  CK_FUNCTION_LIST_PTR p11;
+  CK_RV rv = fn(&p11);
+  assert(rv == CKR_OK);
+
+  return p11;
+}
+
+CK_SESSION_HANDLE open_session(CK_FUNCTION_LIST_PTR p11) {
+  CK_SESSION_HANDLE session;
+  CK_C_INITIALIZE_ARGS initArgs;
+  memset(&initArgs, 0, sizeof(initArgs));
+
+  const char *connector_url;
+  connector_url = getenv("DEFAULT_CONNECTOR_URL");
+  if (connector_url == NULL) {
+    connector_url = DEFAULT_CONNECTOR_URL;
+  }
+  char config[256];
+  assert(strlen(connector_url) + strlen("connector=") < 256);
+  sprintf(config, "connector=%s", connector_url);
+  initArgs.pReserved = (void *) config;
+  CK_RV rv = p11->C_Initialize(&initArgs);
+  assert(rv == CKR_OK);
+
+  rv = p11->C_OpenSession(0, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL, NULL,
+                          &session);
+  assert(rv == CKR_OK);
+
+  char password[] = "0001password";
+  rv = p11->C_Login(session, CKU_USER, (CK_UTF8CHAR_PTR) password,
+                    (CK_ULONG) strlen(password));
+  assert(rv == CKR_OK);
+  printf("Session open and authenticated\n");
+
+  return session;
+}
+
+void close_session(CK_FUNCTION_LIST_PTR p11, CK_SESSION_HANDLE session) {
+  CK_RV rv = p11->C_Logout(session);
+  assert(rv == CKR_OK);
+
+  rv = p11->C_Finalize(NULL);
+  assert(rv == CKR_OK);
+}
+
+void print_session_state(CK_FUNCTION_LIST_PTR p11, CK_SESSION_HANDLE session) {
+  CK_SESSION_INFO pInfo;
+  CK_RV rv = p11->C_GetSessionInfo(session, &pInfo);
+  assert(rv == CKR_OK);
+  CK_STATE state = pInfo.state;
+
+  printf("session state: ");
+  switch (state) {
+    case 0:
+      printf("read-only public session\n");
+      break;
+    case 1:
+      printf("read-only user functions\n");
+      break;
+    case 2:
+      printf("read-write public session\n");
+      break;
+    case 3:
+      printf("read-write user functions\n");
+      break;
+    case 4:
+      printf("read-write so functions\n");
+      break;
+    default:
+      printf("unknown state\n");
+      break;
+  }
+}
+
+bool destroy_object(CK_FUNCTION_LIST_PTR p11, CK_SESSION_HANDLE session,
+                    CK_OBJECT_HANDLE key) {
+  if ((p11->C_DestroyObject(session, key)) != CKR_OK) {
+    printf("WARN. Failed to destroy object 0x%lx on HSM. FAIL\n", key);
+    return false;
+  }
+  return true;
+}

--- a/pkcs11/tests/common.c
+++ b/pkcs11/tests/common.c
@@ -83,6 +83,9 @@ void close_session(CK_FUNCTION_LIST_PTR p11, CK_SESSION_HANDLE session) {
   CK_RV rv = p11->C_Logout(session);
   assert(rv == CKR_OK);
 
+  rv = p11->C_CloseSession(session);
+  assert(rv == CKR_OK);
+
   rv = p11->C_Finalize(NULL);
   assert(rv == CKR_OK);
 }

--- a/pkcs11/tests/common.h
+++ b/pkcs11/tests/common.h
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2021 Yubico AB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef YUBIHSM_PKCS11_TESTS_COMMON_H
+#define YUBIHSM_PKCS11_TESTS_COMMON_H
+
+#include <stdbool.h>
+#include "../pkcs11.h"
+
+#ifndef DEFAULT_CONNECTOR_URL
+#define DEFAULT_CONNECTOR_URL "http://127.0.0.1:12345"
+#endif
+
+CK_FUNCTION_LIST_PTR get_function_list(char *argv[]);
+CK_SESSION_HANDLE open_session(CK_FUNCTION_LIST_PTR p11);
+void close_session(CK_FUNCTION_LIST_PTR p11, CK_SESSION_HANDLE session);
+void print_session_state(CK_FUNCTION_LIST_PTR p11, CK_SESSION_HANDLE session);
+bool destroy_object(CK_FUNCTION_LIST_PTR p11, CK_SESSION_HANDLE session,
+                    CK_OBJECT_HANDLE key);
+
+#endif

--- a/pkcs11/tests/common.h
+++ b/pkcs11/tests/common.h
@@ -24,7 +24,9 @@
 #define DEFAULT_CONNECTOR_URL "http://127.0.0.1:12345"
 #endif
 
-CK_FUNCTION_LIST_PTR get_function_list(char *argv[]);
+void *open_module(const char *path);
+void close_module(void *handle);
+CK_FUNCTION_LIST_PTR get_function_list(void *handle);
 CK_SESSION_HANDLE open_session(CK_FUNCTION_LIST_PTR p11);
 void close_session(CK_FUNCTION_LIST_PTR p11, CK_SESSION_HANDLE session);
 void print_session_state(CK_FUNCTION_LIST_PTR p11, CK_SESSION_HANDLE session);

--- a/pkcs11/tests/ecdh_derive_test.c
+++ b/pkcs11/tests/ecdh_derive_test.c
@@ -18,7 +18,6 @@
 #undef NDEBUG
 #endif
 #include <assert.h>
-#include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -28,10 +27,7 @@
 #include <openssl/x509.h>
 
 #include "../pkcs11.h"
-
-#ifndef DEFAULT_CONNECTOR_URL
-#define DEFAULT_CONNECTOR_URL "http://127.0.0.1:12345"
-#endif
+#include "common.h"
 
 #define BUFSIZE 1024
 
@@ -41,8 +37,8 @@ CK_BYTE P256_PARAMS[] = {0x06, 0x08, 0x2a, 0x86, 0x48,
 CK_BYTE P384_PARAMS[] = {0x06, 0x05, 0x2b, 0x81, 0x04, 0x00, 0x22};
 CK_BYTE P521_PARAMS[] = {0x06, 0x05, 0x2b, 0x81, 0x04, 0x00, 0x23};
 
-CK_FUNCTION_LIST_PTR p11;
-CK_SESSION_HANDLE session;
+static CK_FUNCTION_LIST_PTR p11;
+static CK_SESSION_HANDLE session;
 
 char *CURVES[] = {"secp224r1", "prime256v1", "secp384r1", "secp521r1"};
 CK_BYTE *CURVE_PARAMS[] = {P224_PARAMS, P256_PARAMS, P384_PARAMS, P521_PARAMS};
@@ -50,93 +46,9 @@ CK_ULONG CURVE_LENS[] = {sizeof(P224_PARAMS), sizeof(P256_PARAMS),
                          sizeof(P384_PARAMS), sizeof(P521_PARAMS)};
 int CURVE_COUNT = sizeof(CURVE_PARAMS) / sizeof(CURVE_PARAMS[0]);
 
-static void get_function_list(char *argv[]) {
-  void *handle = dlopen(argv[1], RTLD_NOW | RTLD_GLOBAL);
-  assert(handle != NULL);
-  CK_C_GetFunctionList fn;
-
-  *(void **) (&fn) = dlsym(handle, "C_GetFunctionList");
-  assert(fn != NULL);
-
-  CK_RV rv = fn(&p11);
-  assert(rv == CKR_OK);
-}
-
-static void open_session() {
-  CK_C_INITIALIZE_ARGS initArgs;
-  memset(&initArgs, 0, sizeof(initArgs));
-
-  const char *connector_url;
-  connector_url = getenv("DEFAULT_CONNECTOR_URL");
-  if (connector_url == NULL) {
-    connector_url = DEFAULT_CONNECTOR_URL;
-  }
-  char config[256];
-  assert(strlen(connector_url) + strlen("connector=") < 256);
-  sprintf(config, "connector=%s", connector_url);
-  initArgs.pReserved = (void *) config;
-  CK_RV rv = p11->C_Initialize(&initArgs);
-  assert(rv == CKR_OK);
-
-  rv = p11->C_OpenSession(0, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL, NULL,
-                          &session);
-  assert(rv == CKR_OK);
-
-  char password[] = "0001password";
-  rv = p11->C_Login(session, CKU_USER, (CK_UTF8CHAR_PTR) password,
-                    (CK_ULONG) strlen(password));
-  assert(rv == CKR_OK);
-  printf("Session open and authenticated\n");
-}
-
-static void close_session() {
-  CK_RV rv = p11->C_Logout(session);
-  assert(rv == CKR_OK);
-
-  rv = p11->C_Finalize(NULL);
-  assert(rv == CKR_OK);
-}
-
-static void print_session_state() {
-  CK_SESSION_INFO pInfo;
-  CK_RV rv = p11->C_GetSessionInfo(session, &pInfo);
-  assert(rv == CKR_OK);
-  CK_STATE state = pInfo.state;
-
-  printf("session state: ");
-  switch (state) {
-    case 0:
-      printf("read-only public session\n");
-      break;
-    case 1:
-      printf("read-only user functions\n");
-      break;
-    case 2:
-      printf("read-write public session\n");
-      break;
-    case 3:
-      printf("read-write user functions\n");
-      break;
-    case 4:
-      printf("read-write so functions\n");
-      break;
-    default:
-      printf("unknown state\n");
-      break;
-  }
-}
-
 static void success(const char *message) { printf("%s. OK\n", message); }
 
 static void fail(const char *message) { printf("%s. FAIL!\n", message); }
-
-static bool destroy_object(CK_OBJECT_HANDLE key) {
-  if ((p11->C_DestroyObject(session, key)) != CKR_OK) {
-    printf("WARN. Failed to destroy object 0x%lx on HSM. FAIL\n", key);
-    return false;
-  }
-  return true;
-}
 
 static void generate_keypair_yh(CK_BYTE *curve, CK_ULONG curve_len,
                                 CK_OBJECT_HANDLE_PTR publicKeyPtr,
@@ -928,9 +840,9 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
 
-  get_function_list(argv);
-  open_session();
-  print_session_state();
+  p11 = get_function_list(argv);
+  session = open_session(p11);
+  print_session_state(p11, session);
 
   int exit_status = EXIT_SUCCESS;
 
@@ -1076,7 +988,7 @@ int main(int argc, char **argv) {
     // ------- End C_FindObjects functions test
 
     printf("Destroying ECDH key 1... ");
-    destroy_object(ecdh1);
+    destroy_object(p11, session, ecdh1);
     if (find_secret_extractable_keys(&ecdh1, &ecdh2, &ecdh3, 2)) {
       printf("OK!\n");
     } else {
@@ -1086,7 +998,7 @@ int main(int argc, char **argv) {
     }
 
     printf("Destroying ECDH key 2... ");
-    destroy_object(ecdh3);
+    destroy_object(p11, session, ecdh3);
     if (find_secret_extractable_keys(&ecdh1, &ecdh2, &ecdh3, 1)) {
       printf("OK!\n");
     } else {
@@ -1114,7 +1026,7 @@ int main(int argc, char **argv) {
     }
 
     printf("Destroying ECDH key 3... ");
-    destroy_object(ecdh2);
+    destroy_object(p11, session, ecdh2);
     if (find_secret_extractable_keys(&ecdh1, &ecdh2, &ecdh3, 0)) {
       printf("OK!\n");
     } else {
@@ -1123,13 +1035,13 @@ int main(int argc, char **argv) {
       goto c_clean;
     }
 
-    destroy_object(yh_privkey);
+    destroy_object(p11, session, yh_privkey);
   }
 
 c_clean:
   if (exit_status == EXIT_FAILURE) {
-    destroy_object(yh_privkey);
+    destroy_object(p11, session, yh_privkey);
   }
-  close_session();
+  close_session(p11, session);
   return (exit_status);
 }

--- a/pkcs11/tests/ecdh_derive_test.c
+++ b/pkcs11/tests/ecdh_derive_test.c
@@ -840,7 +840,8 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
 
-  p11 = get_function_list(argv);
+  void *handle = open_module(argv[1]);
+  p11 = get_function_list(handle);
   session = open_session(p11);
   print_session_state(p11, session);
 
@@ -1043,5 +1044,6 @@ c_clean:
     destroy_object(p11, session, yh_privkey);
   }
   close_session(p11, session);
+  close_module(handle);
   return (exit_status);
 }

--- a/pkcs11/tests/rsa_enc_test.c
+++ b/pkcs11/tests/rsa_enc_test.c
@@ -18,7 +18,6 @@
 #undef NDEBUG
 #endif
 #include <assert.h>
-#include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -30,99 +29,12 @@
 #include <openssl/err.h>
 
 #include "../pkcs11.h"
-
-#ifndef DEFAULT_CONNECTOR_URL
-#define DEFAULT_CONNECTOR_URL "http://127.0.0.1:12345"
-#endif
+#include "common.h"
 
 #define BUFSIZE 1024
 
-CK_FUNCTION_LIST_PTR p11;
-CK_SESSION_HANDLE session;
-
-static void get_function_list(char *argv[]) {
-  void *handle = dlopen(argv[1], RTLD_NOW | RTLD_GLOBAL);
-  assert(handle != NULL);
-  CK_C_GetFunctionList fn;
-
-  *(void **) (&fn) = dlsym(handle, "C_GetFunctionList");
-  assert(fn != NULL);
-
-  CK_RV rv = fn(&p11);
-  assert(rv == CKR_OK);
-}
-
-static void open_session() {
-  CK_C_INITIALIZE_ARGS initArgs;
-  memset(&initArgs, 0, sizeof(initArgs));
-
-  const char *connector_url;
-  connector_url = getenv("DEFAULT_CONNECTOR_URL");
-  if (connector_url == NULL) {
-    connector_url = DEFAULT_CONNECTOR_URL;
-  }
-  char config[256];
-  assert(strlen(connector_url) + strlen("connector=") < 256);
-  sprintf(config, "connector=%s", connector_url);
-  initArgs.pReserved = (void *) config;
-  CK_RV rv = p11->C_Initialize(&initArgs);
-  assert(rv == CKR_OK);
-
-  rv = p11->C_OpenSession(0, CKF_SERIAL_SESSION | CKF_RW_SESSION, NULL, NULL,
-                          &session);
-  assert(rv == CKR_OK);
-
-  char password[] = "0001password";
-  rv = p11->C_Login(session, CKU_USER, (CK_UTF8CHAR_PTR) password,
-                    (CK_ULONG) strlen(password));
-  assert(rv == CKR_OK);
-  printf("Session open and authenticated\n");
-}
-
-static void close_session() {
-  CK_RV rv = p11->C_Logout(session);
-  assert(rv == CKR_OK);
-
-  rv = p11->C_Finalize(NULL);
-  assert(rv == CKR_OK);
-}
-
-static void print_session_state() {
-  CK_SESSION_INFO pInfo;
-  CK_RV rv = p11->C_GetSessionInfo(session, &pInfo);
-  assert(rv == CKR_OK);
-  CK_STATE state = pInfo.state;
-
-  printf("session state: ");
-  switch (state) {
-    case 0:
-      printf("read-only public session\n");
-      break;
-    case 1:
-      printf("read-only user functions\n");
-      break;
-    case 2:
-      printf("read-write public session\n");
-      break;
-    case 3:
-      printf("read-write user functions\n");
-      break;
-    case 4:
-      printf("read-write so functions\n");
-      break;
-    default:
-      printf("unknown state\n");
-      break;
-  }
-}
-
-static bool destroy_object(CK_OBJECT_HANDLE key) {
-  if ((p11->C_DestroyObject(session, key)) != CKR_OK) {
-    printf("WARN. Failed to destroy object 0x%lx on HSM. FAIL\n", key);
-    return false;
-  }
-  return true;
-}
+static CK_FUNCTION_LIST_PTR p11;
+static CK_SESSION_HANDLE session;
 
 static void import_rsa_key(int keylen, EVP_PKEY **evp, RSA **rsak,
                            CK_OBJECT_HANDLE_PTR keyid) {
@@ -299,7 +211,7 @@ static void test_encrypt_RSA(int keysize, CK_ULONG expected_enc_len) {
 
   RSA_free(rsak);
   EVP_PKEY_free(evp);
-  destroy_object(keyid);
+  destroy_object(p11, session, keyid);
 }
 
 int main(int argc, char **argv) {
@@ -309,14 +221,14 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
 
-  get_function_list(argv);
-  open_session();
-  print_session_state();
+  p11 = get_function_list(argv);
+  session = open_session(p11);
+  print_session_state(p11, session);
 
   test_encrypt_RSA(2048, 256);
   test_encrypt_RSA(3072, 384);
   test_encrypt_RSA(4096, 512);
 
-  close_session();
+  close_session(p11, session);
   return (EXIT_SUCCESS);
 }

--- a/pkcs11/tests/rsa_enc_test.c
+++ b/pkcs11/tests/rsa_enc_test.c
@@ -221,7 +221,8 @@ int main(int argc, char **argv) {
     exit(EXIT_FAILURE);
   }
 
-  p11 = get_function_list(argv);
+  void *handle = open_module(argv[1]);
+  p11 = get_function_list(handle);
   session = open_session(p11);
   print_session_state(p11, session);
 
@@ -230,5 +231,6 @@ int main(int argc, char **argv) {
   test_encrypt_RSA(4096, 512);
 
   close_session(p11, session);
+  close_module(handle);
   return (EXIT_SUCCESS);
 }

--- a/pkcs11/util_pkcs11.c
+++ b/pkcs11/util_pkcs11.c
@@ -2608,52 +2608,30 @@ CK_RV perform_rsa_encrypt(yh_session *session, yubihsm_pkcs11_op_info *op_info,
 
   if (data == NULL) {
     DBG_ERR("data is null");
+    return CKR_ARGUMENTS_BAD;
   }
 
-  uint8_t response[2048] = {0};
-  size_t response_len = sizeof(response);
-  yh_algorithm algo;
-  if (yh_util_get_public_key(session, op_info->op.encrypt.key_id, response,
-                             &response_len, &algo) != YHR_SUCCESS) {
-    DBG_ERR("Failed to get public key with ObjectId 0x%4x",
-            op_info->op.encrypt.key_id);
-    return CKR_FUNCTION_FAILED;
-  }
-
-  EVP_PKEY *public_key = NULL;
-  public_key = EVP_PKEY_new();
+  EVP_PKEY *public_key = EVP_PKEY_new();
   if (public_key == NULL) {
     DBG_ERR("Failed to create EVP_PKEY object for public key");
     return CKR_FUNCTION_FAILED;
   }
 
-  RSA *rsa = RSA_new();
-  if (rsa == NULL) {
-    DBG_ERR("Failed to create RSA object for public key");
-    return CKR_FUNCTION_FAILED;
-  }
-  BIGNUM *e = BN_new();
-  BIGNUM *n = BN_bin2bn(response, response_len, NULL);
-  BN_hex2bn(&e, "10001");
-  if (RSA_set0_key(rsa, n, e, NULL) != 1) {
-    RSA_free(rsa);
-    DBG_ERR("Failed to set RSA key for encryption");
-    return CKR_FUNCTION_FAILED;
-  }
-  if (EVP_PKEY_set1_RSA(public_key, rsa) != 1) {
-    RSA_free(rsa);
-    DBG_ERR("Failed to set RSA public key for encryption");
-    return CKR_FUNCTION_FAILED;
-  }
-  RSA_free(rsa);
+  CK_RV rv = CKR_OK;
+  EVP_PKEY_CTX *ctx = NULL;
 
-  DBG_INFO("Successfully retrieved RSA key 0x%04x for encryption",
-           op_info->op.encrypt.key_id);
+  if (load_public_key(session, op_info->op.encrypt.key_id, public_key) ==
+      false) {
+    DBG_ERR("Failed to load public key");
+    rv = CKR_FUNCTION_FAILED;
+    goto rsa_enc_cleanup;
+  }
 
-  CK_RV rv;
-  EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new(public_key, NULL);
+  ctx = EVP_PKEY_CTX_new(public_key, NULL);
   if (ctx == NULL) {
-    return CKR_FUNCTION_FAILED;
+    DBG_ERR("Failed to create EVP_PKEY_CTX object for public key");
+    rv = CKR_FUNCTION_FAILED;
+    goto rsa_enc_cleanup;
   }
 
   if (EVP_PKEY_encrypt_init(ctx) <= 0) {
@@ -2718,6 +2696,7 @@ rsa_enc_cleanup:
     free(op_info->op.encrypt.oaep_label);
   }
   EVP_PKEY_CTX_free(ctx);
+  EVP_PKEY_free(public_key);
   return rv;
 }
 

--- a/pkcs11/util_pkcs11.c
+++ b/pkcs11/util_pkcs11.c
@@ -1051,6 +1051,9 @@ static bool load_public_key(yh_session *session, uint16_t id, EVP_PKEY *key) {
       goto l_p_k_failure;
     }
 
+    n = NULL;
+    e = NULL;
+
     if (EVP_PKEY_assign_RSA(key, rsa) == 0) {
       goto l_p_k_failure;
     }
@@ -1099,25 +1102,13 @@ static bool load_public_key(yh_session *session, uint16_t id, EVP_PKEY *key) {
   return true;
 
 l_p_k_failure:
-  if (ec_point != NULL) {
-    EC_POINT_free(ec_point);
-  }
-
-  if (ec_group != NULL) {
-    EC_GROUP_free(ec_group);
-  }
-
-  if (ec_key != NULL) {
-    EC_KEY_free(ec_key);
-  }
-
-  if (rsa != NULL) {
-    RSA_free(rsa);
-  }
-
-  if (key != NULL) {
-    EVP_PKEY_free(key);
-  }
+  EC_POINT_free(ec_point);
+  EC_GROUP_free(ec_group);
+  EC_KEY_free(ec_key);
+  RSA_free(rsa);
+  EVP_PKEY_free(key);
+  BN_free(n);
+  BN_free(e);
 
   return false;
 }


### PR DESCRIPTION
Introduces a common source file for the PKCS#11 tests to deduplicate
helper functions used to load the module, set up a session, etc.