### PR TITLE
Naimul - Added Wno-missing-field-initializers 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,8 @@ else()
 
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-format-zero-length")
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-braces")
-
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-field-initializers")
+  
   include(CheckFunctionExists)
 
   check_function_exists(memset_s HAVE_MEMSET_S)


### PR DESCRIPTION
This is added to suppress the error during the build process.