### PR TITLE
add optional --ykhsmauth-reader cmdline option

### DIFF
--- a/src/cmdline.ggo
+++ b/src/cmdline.ggo
@@ -67,6 +67,7 @@ option "domains" d "Object domains" string optional default="1,2,3,4,5,6,7,8,9,1
 option "capabilities" c "Capabilities for an object" string optional default="0"
 option "object-type" t "Object type" string optional
 option "ykhsmauth-label" - "Credential label on YubiKey (implicitly enables ykhsmauth)" string optional
+option "ykhsmauth-reader" - "Yubikey Reader String" string optional
 
 option "delegated" - "Delegated capabilities" string optional default="0"
 option "new-password" - "New authentication password" string optional

--- a/src/commands.c
+++ b/src/commands.c
@@ -1578,6 +1578,7 @@ int yh_com_open_session_asym(yubihsm_context *ctx, Argument *argv,
 // arg 0: w:authkey
 // arg 1: s:name
 // arg 2: i:password
+// arg 3: s: reader string
 int yh_com_open_yksession(yubihsm_context *ctx, Argument *argv,
                           cmd_format in_fmt, cmd_format fmt) {
   UNUSED(in_fmt);
@@ -1588,7 +1589,7 @@ int yh_com_open_yksession(yubihsm_context *ctx, Argument *argv,
     return -1;
   }
 
-  ykhsmauth_rc ykhsmauthrc = ykhsmauth_connect(ctx->state, NULL);
+  ykhsmauth_rc ykhsmauthrc = ykhsmauth_connect(ctx->state, argv[3].s);
   if (ykhsmauthrc != YKHSMAUTHR_SUCCESS) {
     fprintf(stderr, "Failed to connect to the YubiKey: %s\n",
             ykhsmauth_strerror(ykhsmauthrc));

--- a/src/main.c
+++ b/src/main.c
@@ -2039,6 +2039,14 @@ int main(int argc, char *argv[]) {
         arg[1].len = strlen(args_info.ykhsmauth_label_arg);
         arg[2].x = buf;
         arg[2].len = pw_len;
+        if (args_info.ykhsmauth_reader_given) {
+          arg[3].s = args_info.ykhsmauth_reader_arg;
+          arg[3].len = strlen(args_info.ykhsmauth_reader_arg);
+        }
+        else {
+          arg[3].s = NULL;
+          arg[3].len = 0;
+        }
         comrc = yh_com_open_yksession(&g_ctx, arg, fmt_nofmt, fmt_nofmt);
       } else {
 #endif


### PR DESCRIPTION
add optional --ykhsmauth-reader cmdline option for specifying a specific Yubikey reader as identified by ykman list -r