### PR TITLE
Avoid RHEL 7.9 issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ endif ()
 if (CMAKE_C_COMPILER_ID STREQUAL AppleClang)
   set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-nullability-completeness -Wno-nullability-extension -Wno-expansion-to-defined -Wno-undef-prefix")
 elseif (NOT MSVC)
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-braces -Wno-missing-field-initializers")
   # -Wl,--strip-all is dependent on linker not compiler...
   set (CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} -Wl,--strip-all")
 endif ()
@@ -139,9 +140,6 @@ if(MSVC)
 else()
   message(STATUS "not win32")
 
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-braces")
-  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-missing-field-initializers")
-  
   include(CheckFunctionExists)
 
   check_function_exists(memset_s HAVE_MEMSET_S)

--- a/src/main.c
+++ b/src/main.c
@@ -61,6 +61,7 @@
 #include <strings.h>
 #include <unistd.h>
 #include <sys/time.h>
+#include <sys/ioctl.h>
 #include <editline/readline.h>
 #include <histedit.h>
 
@@ -944,13 +945,13 @@ static int tokenize(char *line, char **toks, int max_toks, int *cursorc,
   int tok = 0;
   int length = strlen(line);
   int start_of_word = 0;
-  enum states { SPACE, WORD, QUOTE } state = SPACE;
+  enum states { WHITESPACE, WORD, QUOTE } state = WHITESPACE;
   toks[0] = line; // set up as fall-through
 
   for (i = 0; i <= length; i++) {
     char c = line[i];
     if (cursorc && i == *cursorc && tok > 0) {
-      if (state == SPACE) {
+      if (state == WHITESPACE) {
         *cursoro = 0;
         *cursorc = tok;
       } else {
@@ -965,7 +966,7 @@ static int tokenize(char *line, char **toks, int max_toks, int *cursorc,
       return -1;
     }
     switch (state) {
-      case SPACE: {
+      case WHITESPACE: {
         bool found = false;
         for (size_t j = 0; j < strlen(space); j++) {
           if (c == space[j]) {
@@ -990,14 +991,14 @@ static int tokenize(char *line, char **toks, int max_toks, int *cursorc,
       case QUOTE:
         if (c == '"') {
           line[i] = '\0';
-          state = SPACE;
+          state = WHITESPACE;
         }
         break;
       case WORD:
         for (size_t j = 0; j < strlen(space); j++) {
           if (c == space[j]) {
             line[i] = '\0';
-            state = SPACE;
+            state = WHITESPACE;
           }
         }
         break;


### PR DESCRIPTION
Fix apparent issues with the source on RHEL 7.9, and only set initializer flags on Linux, as they are not needed on macos