### PR TITLE
lib/curl: backend_create() explicitly takes no arguments

### DIFF
--- a/lib/yubihsm_curl.c
+++ b/lib/yubihsm_curl.c
@@ -83,7 +83,7 @@ static yh_rc backend_init(uint8_t verbosity, FILE *output) {
   return YHR_SUCCESS;
 }
 
-static yh_backend *backend_create() {
+static yh_backend *backend_create(void) {
   DBG_INFO("backend_create");
   return curl_easy_init();
 }


### PR DESCRIPTION
clang-15 and later will otherwise issue warnings under `-Wstrict-prototypes -pedantic`.