### PR TITLE
tests: ensure that variables are set before use

### DIFF
--- a/resources/tests/bash/test_eckey.sh
+++ b/resources/tests/bash/test_eckey.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -u
 
 if [ "$#" -ne 1 ]; then
   BIN="yubihsm-shell"

--- a/resources/tests/bash/test_eckey.sh
+++ b/resources/tests/bash/test_eckey.sh
@@ -375,7 +375,7 @@ is_fedora=$?
 cat /etc/os-release | grep 'CentOS Linux 7'
 is_centos7=$?
 set -e
-if [ $is_fedora -ne 0 ] && [ $is_centos -ne 0 ]; then
+if [ $is_fedora -ne 0 ] && [ $is_centos7 -ne 0 ]; then
   echo "------------- Brainpool256"
   echo "Generate key:"
   test_with_resp "$BIN -p password -a generate-asymmetric-key -i 0 -l ecKey -d 5,8,13 -c sign-ecdsa,derive-ecdh,sign-attestation-certificate -A ecbp256" "   Generate key"

--- a/resources/tests/bash/test_edkey.sh
+++ b/resources/tests/bash/test_edkey.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -u
 
 if [ "$#" -ne 1 ]; then
   BIN="yubihsm-shell"

--- a/resources/tests/bash/test_hmackey.sh
+++ b/resources/tests/bash/test_hmackey.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -u
 
 if [ "$#" -ne 1 ]; then
   BIN="yubihsm-shell"

--- a/resources/tests/bash/test_otpaeadkey.sh
+++ b/resources/tests/bash/test_otpaeadkey.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -u
 
 if [ "$#" -ne 1 ]; then
   BIN="yubihsm-shell"

--- a/resources/tests/bash/test_rsakey.sh
+++ b/resources/tests/bash/test_rsakey.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -u
 
 if [ "$#" -ne 1 ]; then
   BIN="yubihsm-shell"

--- a/resources/tests/bash/test_wrapkey.sh
+++ b/resources/tests/bash/test_wrapkey.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -u
 
 if [ "$#" -ne 1 ]; then
   BIN="yubihsm-shell"


### PR DESCRIPTION
While here, fix an incorrect variable name and missing newlines at EOF.