### PR TITLE
fix list-object output formatting

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -1562,7 +1562,7 @@ int yh_com_list_objects(yubihsm_context *ctx, Argument *argv, cmd_format in_fmt,
     const char *algo = "";
     yh_algo_to_string(objects[i].algorithm, &algo);
     fprintf(ctx->out,
-            "id: 0x%04x, type: %s, algo: %s, sequence: %hhu label: %s\n",
+            "id: 0x%04x, type: %s, algo: %s, sequence: %hhu, label: %s\n",
             objects[i].id, type, algo, objects[i].sequence, objects[i].label);
   }
   return 0;


### PR DESCRIPTION
adding a "," between sequence and label is more consistent and simplifies parsing of list-objects output.