### PR TITLE
Allow fetching passwords from environment variables

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1448,13 +1448,23 @@ static FILE *open_file(const char *name, bool input) {
 
 static bool get_input_data(const char *name, uint8_t **out, size_t *len,
                            cmd_format fmt) {
-  const char *fname = strncasecmp(name, "file:", 5) ? name : name + 5;
+  bool is_file = !strncasecmp(name, "file:", 5);
+  bool is_envvar = !strncasecmp(name, "env:", 4);
+  const char *fname = is_file ? name + 5 : name;
+  const char *envvar = is_envvar ? name + 4 : NULL;
   struct stat sb = {0};
   int st_res = stat(fname, &sb);
   if (st_res == 0 && S_ISREG(sb.st_mode)) {
     *len = sb.st_size;
+    is_file = true;
   } else {
     *len = ARGS_BUFFER_SIZE;
+  }
+  if (!is_file && !strcmp(name, "-")) {
+    is_file = true;
+  }
+  if (is_envvar) {
+    is_envvar = !!getenv(envvar);
   }
   *out = calloc(*len + 1, 1);
   if (*out == 0) {
@@ -1462,8 +1472,7 @@ static bool get_input_data(const char *name, uint8_t **out, size_t *len,
             fname);
     return false;
   }
-  if (!strcmp(name, "-") || fname != name ||
-      (st_res == 0 && S_ISREG(sb.st_mode))) {
+  if (is_file) {
     bool ret = false;
     FILE *file = open_file(fname, true);
     if (!file) {
@@ -1501,6 +1510,15 @@ static bool get_input_data(const char *name, uint8_t **out, size_t *len,
     }
     if (ret == false) {
       return ret;
+    }
+  } else if (is_envvar) {
+    const char *data = getenv(envvar);
+    size_t dlen = strlen(data);
+    if (dlen < *len) {
+      memcpy(*out, data, dlen);
+      *len = dlen;
+    } else {
+      return false;
     }
   } else {
     if (strlen(name) < *len) {


### PR DESCRIPTION
Passing sensitive data through command line args is not generally safe on many *nix systems, because the arguments leak to all users, such as through /proc/PID/cmdline on Linux.

Instead, the usual pattern for passing passwords to programs is via environment variables, which do not leak to all users. Wire up the input getter's logic to handle these.

The existing logic is:
- If the argument is a file that exists or starts with file:, treat it as a file and read its contents.
- Otherwise, treat it as the data itself.

The new logic is:
- If the argument is a file that exists or starts with file:, treat it as a file and read its contents.
- If the argument starts with env: and that environment variable exists, treat it as an environment variable and read its contents.
- Otherwise, treat it as the data itself.

Requiring the environment variable to actually exist -- much like how file's unprefixed by file: have to exist to be considered as files -- will mitigate false positives of, e.g., actual passwords that begin with "env:", so the potential for regression should be exceedingly low.