### PR TITLE
Fix typos in pkg-config templates

### DIFF
--- a/lib/yubihsm.pc.in
+++ b/lib/yubihsm.pc.in
@@ -1,5 +1,5 @@
 libdir=-L@YUBIHSM_INSTALL_LIB_DIR@
-includedir=-I@INSTALL_INC_DIR@
+includedir=-I@YUBIHSM_INSTALL_INC_DIR@
 
 Name: yubihsm
 Description: Yubico YubiHSM C Library

--- a/ykhsmauth/ykhsmauth.pc.in
+++ b/ykhsmauth/ykhsmauth.pc.in
@@ -1,5 +1,5 @@
 libdir=-L@YUBIHSM_INSTALL_LIB_DIR@
-includedir=@INSTALL_INC_DIR@
+includedir=@YUBIHSM_INSTALL_INC_DIR@
 
 Name: ykhsmauth
 Description: Yubico YubiHSM application for YubiKey C Library


### PR DESCRIPTION
This commit fixes `*.pc.in` files to use `YUBIHSM_INSTALL_INC_DIR` instead of `INSTALL_INC_DIR`. The resulting pkg-config files have the correct paths for compiler flags.