### PR TITLE
fix buffer_length check for EdDSA in util_pkcs11.c

### DIFF
--- a/pkcs11/util_pkcs11.c
+++ b/pkcs11/util_pkcs11.c
@@ -2223,7 +2223,6 @@ CK_RV apply_sign_mechanism_update(yubihsm_pkcs11_op_info *op_info,
       break;
 
     case CKM_ECDSA:
-    case CKM_EDDSA:
       if (op_info->buffer_length + in_len > 128) {
         // NOTE(adma): Specs say ECDSA only supports data up to 1024 bit
         return CKR_DATA_LEN_RANGE;
@@ -2238,6 +2237,7 @@ CK_RV apply_sign_mechanism_update(yubihsm_pkcs11_op_info *op_info,
     case CKM_SHA256_HMAC:
     case CKM_SHA384_HMAC:
     case CKM_SHA512_HMAC:
+    case CKM_EDDSA:
       if (op_info->buffer_length + in_len > sizeof(op_info->buffer)) {
         return CKR_DATA_LEN_RANGE;
       }


### PR DESCRIPTION
Having problems signing with EdDSA on YubiHSM2 via PKCS11. Getting an 
pkcs11:p11prov_Sign:The size of plaintext input data to a cryptographic operation is invalid (Out of range):interface.gen.c:679:Error returned by C_Sign error

As I understand the PKCS11 v3.0 spec, the 1024 bit limit (note by "adma" in line 2228) applies only to "ECDSA without hashing" (CKM_ECDSA) as it only processes a hash value.

see: https://docs.oasis-open.org/pkcs11/pkcs11-curr/v3.0/os/pkcs11-curr-v3.0-os.html#_Toc30061189

EdDSA does not have this limit, so the size of "op_info->buffer" should be the limiting factor

see: https://docs.oasis-open.org/pkcs11/pkcs11-curr/v3.0/os/pkcs11-curr-v3.0-os.html#_Toc30061191