### PR TITLE
pkcs11: Fix format string

### DIFF
--- a/pkcs11/yubihsm_pkcs11.c
+++ b/pkcs11/yubihsm_pkcs11.c
@@ -5667,7 +5667,7 @@ CK_DEFINE_FUNCTION(CK_RV, C_DeriveKey)
   ecdh_key.id = ECDH_KEY_TYPE << 16 | seq;
   ecdh_key.len = sizeof(ecdh_key.ecdh_key);
 
-  DBG_INFO("ecdh_key.id = %zu", ecdh_key.id);
+  DBG_INFO("ecdh_key.id = %lu", ecdh_key.id);
 
   if (value_len > ecdh_key.len) {
     DBG_ERR("Requested derived key is too long");


### PR DESCRIPTION
This problem fails the build on 32 b architectures:
```
/usr/bin/gcc -O2 -flto=auto -ffat-lto-objects -fexceptions -g -grecord-gcc-switches -pipe -Wall -Werror=format-security -Wp,-U_FORTIFY_SOURCE,-D_FORTIFY_SOURCE=3 -Wp,-D_GLIBCXX_ASSERTIONS -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -fstack-protector-strong -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -m32 -march=i686 -mtune=generic -msse2 -mfpmath=sse -mstackrealign -fasynchronous-unwind-tables -fstack-clash-protection  -Wno-error=deprecated-declarations -flto -Wno-missing-braces -Wno-missing-field-initializers -g -Wl,-z,relro -Wl,--as-needed  -Wl,-z,pack-relative-relocs -Wl,-z,now -specs=/usr/lib/rpm/redhat/redhat-hardened-ld-errors -specs=/usr/lib/rpm/redhat/redhat-hardened-ld -specs=/usr/lib/rpm/redhat/redhat-annobin-cc1  -Wl,--build-id=sha1 -specs=/usr/lib/rpm/redhat/redhat-package-notes -fstack-protector-all -pie -Wl,-z,noexecstack -Wl,-z,relro,-z,now CMakeFiles/test_parsing.dir/test_parsing.c.o -o test_parsing  -Wl,-rpath,/builddir/build/BUILD/yubihsm-shell-2.5.0/redhat-linux-build/lib ../libyubihsm.so.2.5.0 -L/usr/lib -lcrypto -ldl 
In file included from /builddir/build/BUILD/yubihsm-shell-2.5.0/pkcs11/debug_p11.h:23,
                 from /builddir/build/BUILD/yubihsm-shell-2.5.0/pkcs11/yubihsm_pkcs11.c:29:
/builddir/build/BUILD/yubihsm-shell-2.5.0/pkcs11/yubihsm_pkcs11.c: In function ‘C_DeriveKey’:
/builddir/build/BUILD/yubihsm-shell-2.5.0/pkcs11/yubihsm_pkcs11.c:5670:12: error: format ‘%zu’ expects argument of type ‘size_t’, but argument 3 has type ‘CK_OBJECT_HANDLE’ {aka ‘long unsigned int’} [-Werror=format=]
 5670 |   DBG_INFO("ecdh_key.id = %zu", ecdh_key.id);
      |            ^~~~~~~~~~~~~~~~~~~  ~~~~~~~~~~~
      |                                         |
      |                                         CK_OBJECT_HANDLE {aka long unsigned int}
/builddir/build/BUILD/yubihsm-shell-2.5.0/pkcs11/../common/debug.h:65:19: note: in definition of macro ‘D’
   65 |     fprintf(file, __VA_ARGS__);                                                \
      |                   ^~~~~~~~~~~
/builddir/build/BUILD/yubihsm-shell-2.5.0/pkcs11/debug_p11.h:33:5: note: in expansion of macro ‘DLN’
   33 |     DLN(_YHP11_DBG, _YHP11_OUTPUT, ANSI_BLUE, "P11", "INF", __VA_ARGS__);      \
      |     ^~~
/builddir/build/BUILD/yubihsm-shell-2.5.0/pkcs11/yubihsm_pkcs11.c:5670:3: note: in expansion of macro ‘DBG_INFO’
 5670 |   DBG_INFO("ecdh_key.id = %zu", ecdh_key.id);
      |   ^~~~~~~~
/builddir/build/BUILD/yubihsm-shell-2.5.0/pkcs11/yubihsm_pkcs11.c:5670:29: note: format string is defined here
 5670 |   DBG_INFO("ecdh_key.id = %zu", ecdh_key.id);
      |                           ~~^
      |                             |
      |                             unsigned int
      |                           %lu
```
https://kojipkgs.fedoraproject.org//work/tasks/289/115770289/build.log