### PR TITLE
fix binary output to stdout

### DIFF
--- a/common/util.c
+++ b/common/util.c
@@ -704,7 +704,9 @@ bool write_file(const uint8_t *buf, size_t buf_len, FILE *fp, format_t format) {
   } while (!feof(fp) && !ferror(fp) && length > 0);
 
   if (fp == stdout || fp == stderr) {
-    fprintf(fp, "\n");
+    if ( format != _binary ) {
+      fprintf(fp, "\n");
+    }
   }
 
   if (b64 != NULL) {


### PR DESCRIPTION
A newline is written to stdout in command-line mode. This causes issues with binary output. For example:

    echo -n 0123456789abcdef | yubihsm-shell -p password -a encrypt-aesecb -i 123 | yubihsm-shell -p password -a decrypt-aesecb -i 123

Other commands have similar issues (e.g. `-a get-pseudo-random --count=16 --outformat binary | wc -c` outputs 17)
This patch simply drops the newline when writing binary output to stdout.