### PR TITLE
YubiHSM Auth: Improve error message

### DIFF
--- a/yubihsm-auth/main.c
+++ b/yubihsm-auth/main.c
@@ -535,7 +535,7 @@ int main(int argc, char *argv[]) {
 
   ykhsmauthrc = ykhsmauth_connect(state, args_info.reader_arg);
   if (ykhsmauthrc != YKHSMAUTHR_SUCCESS) {
-    fprintf(stderr, "Unable to connect: %s\n", ykhsmauth_strerror(ykhsmauthrc));
+    fprintf(stderr, "Unable to connect: %s.\nMaybe yubihsm-auth is not supported or disabled on your YubiKey?\n", ykhsmauth_strerror(ykhsmauthrc));
     goto main_exit;
   }
 


### PR DESCRIPTION
YubiHSM Auth: Improve error message when YubiKey is too old to support yubihsm-auth