### PR TITLE
ykhsmauth: Use LIBPCSC_INCLUDE_DIRS as include dir

### DIFF
--- a/ykhsmauth/CMakeLists.txt
+++ b/ykhsmauth/CMakeLists.txt
@@ -25,7 +25,7 @@ if(WIN32)
 endif(WIN32)
 
 include_directories (
-  ${LIBPCSC_INCLUDEDIR}
+  ${LIBPCSC_INCLUDE_DIRS}
 )
 
 # Uncomment this for Ubuntu 24.10 and higher and Fedora 41 and higher


### PR DESCRIPTION
LIBPCSC_INCLUDEDIR results in /usr/include/PCSC. In a cross-compilation environment (e.g. bitbake) it is missing prepended paths. During build this results the usage of the hosts PCSC include directory. To fix this use LIBPCSC_INCLUDE_DIRS instead.