### PR TITLE
Fuzzer: include lib directory when compiling yubihsm-auth

### DIFF
--- a/yubihsm-auth/CMakeLists.txt
+++ b/yubihsm-auth/CMakeLists.txt
@@ -39,6 +39,7 @@ endif(WIN32)
 include_directories (
   ${LIBCRYPTO_INCLUDEDIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/../ykhsmauth
+  ${CMAKE_CURRENT_SOURCE_DIR}/../lib
   ${CMAKE_CURRENT_SOURCE_DIR}/../common
 )
 


### PR DESCRIPTION
Adding debug_lib.h dependency in aes_cmac requires including "lib"  when building yubihsm-auth