### PR TITLE
Configurable `always-extractable` / `ignore-modifiable` behavior via the PKCS#11 config file

### DIFF
--- a/pkcs11/cmdline.ggo
+++ b/pkcs11/cmdline.ggo
@@ -27,4 +27,6 @@ option "proxy" - "Proxy server to use for connector" string optional
 option "noproxy" - "Comma separated list of hosts ignore proxy for" string optional
 option "timeout" - "Timeout to use for initial connection to connector" int optional default="5"
 option "device-pubkey" - "List of device public keys allowed for asymmetric authentication" string optional multiple
+option "always-extractable" - "Set to true/TRUE/1 to force generated key pairs to be extractable (exportable-under-wrap); false/FALSE/0 or absent honors the requested CKA_EXTRACTABLE" string optional
+option "ignore-modifiable" - "Set to true/TRUE/1 to ignore the CKA_MODIFIABLE attribute in RSA/EC key templates; false/FALSE/0 or absent keeps the default behavior" string optional
 

--- a/pkcs11/util_pkcs11.c
+++ b/pkcs11/util_pkcs11.c
@@ -4278,13 +4278,13 @@ CK_RV parse_rsa_template(CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount,
         break;
       
       case CKA_MODIFIABLE:
-       if (!is_cka_modifiable_ignore) {
-         if ((rv = check_bool_attribute(pTemplate[i].pValue, false)) !=
-             CKR_OK) {
-           return rv;
-         }
-       }
-       break;
+        if (!is_cka_modifiable_ignore) {
+          if ((rv = check_bool_attribute(pTemplate[i].pValue, false)) !=
+              CKR_OK) {
+            return rv;
+          }
+        }
+        break;
       
       default:
         DBG_ERR("Invalid attribute type in key template: 0x%lx\n",
@@ -4485,7 +4485,7 @@ CK_RV parse_ec_template(CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount,
            return rv;
          }
         }
-      break;
+        break;
       
       default:
         DBG_ERR("Invalid attribute type in key template: 0x%lx\n",
@@ -4558,7 +4558,7 @@ CK_RV parse_ed_template(CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount,
            return rv;
          }
         }
-      break;
+        break;
 
       default:
         return CKR_ATTRIBUTE_TYPE_INVALID;
@@ -4869,14 +4869,14 @@ CK_RV parse_rsa_generate_template(CK_ATTRIBUTE_PTR pPublicKeyTemplate,
 
       case CKA_MODIFIABLE:
         if (!is_cka_modifiable_ignore) {
-          if ((rv = check_bool_attribute(pTemplate[i].pValue, false)) !=
+          if ((rv = check_bool_attribute(pPublicKeyTemplate[i].pValue, false)) !=
              CKR_OK) {
               DBG_ERR("Boolean false check failed for attribute 0x%lx",
                       pPublicKeyTemplate[i].type);
            return rv;
          }
         }
-      break;
+        break;
      
       default:
         DBG_ERR("Invalid attribute type in PublicKeyTemplate: 0x%lx",
@@ -4989,7 +4989,6 @@ CK_RV parse_rsa_generate_template(CK_ATTRIBUTE_PTR pPublicKeyTemplate,
       case CKA_SIGN_RECOVER:
       case CKA_VERIFY:
       case CKA_VERIFY_RECOVER:
-      case CKA_MODIFIABLE:
       case CKA_COPYABLE:
         if ((rv = check_bool_attribute(pPrivateKeyTemplate[i].pValue, false)) !=
             CKR_OK) {
@@ -5002,6 +5001,17 @@ CK_RV parse_rsa_generate_template(CK_ATTRIBUTE_PTR pPublicKeyTemplate,
       case CKA_SUBJECT:
         break;
 
+      case CKA_MODIFIABLE:
+        if (!is_cka_modifiable_ignore) {
+          if ((rv = check_bool_attribute(pPrivateKeyTemplate[i].pValue, false)) !=
+             CKR_OK) {
+              DBG_ERR("Boolean false check failed for attribute 0x%lx",
+                      pPrivateKeyTemplate[i].type);
+           return rv;
+         }
+        }
+        break;
+ 
       default:
         DBG_ERR("Invalid attribute type in PrivateKeyTemplate: 0x%lx",
                 pPrivateKeyTemplate[i].type);
@@ -5123,14 +5133,14 @@ CK_RV parse_ec_generate_template(CK_ATTRIBUTE_PTR pPublicKeyTemplate,
 
       case CKA_MODIFIABLE:
         if (!is_cka_modifiable_ignore) {
-          if ((rv = check_bool_attribute(pTemplate[i].pValue, false)) !=
+          if ((rv = check_bool_attribute(pPublicKeyTemplate[i].pValue, false)) !=
              CKR_OK) {
               DBG_ERR("Boolean false check failed for attribute 0x%lx",
                       pPublicKeyTemplate[i].type);
            return rv;
          }
         }
-      break;
+        break;
     
       default:
         DBG_ERR("Invalid attribute type in PublicKeyTemplate: 0x%lx",
@@ -5220,7 +5230,6 @@ CK_RV parse_ec_generate_template(CK_ATTRIBUTE_PTR pPublicKeyTemplate,
       case CKA_DECRYPT:
       case CKA_SIGN_RECOVER:
       case CKA_VERIFY_RECOVER:
-      case CKA_MODIFIABLE:
       case CKA_COPYABLE:
         if ((rv = check_bool_attribute(pPrivateKeyTemplate[i].pValue, false)) !=
             CKR_OK) {
@@ -5233,6 +5242,17 @@ CK_RV parse_ec_generate_template(CK_ATTRIBUTE_PTR pPublicKeyTemplate,
       case CKA_SUBJECT:
         break;
 
+      case CKA_MODIFIABLE:
+        if (!is_cka_modifiable_ignore) {
+          if ((rv = check_bool_attribute(pPrivateKeyTemplate[i].pValue, false)) !=
+             CKR_OK) {
+              DBG_ERR("Boolean false check failed for attribute 0x%lx",
+                      pPrivateKeyTemplate[i].type);
+           return rv;
+         }
+        }
+        break;      
+      
       default:
         DBG_ERR("Invalid attribute type in PrivateKeyTemplate: 0x%lx",
                 pPrivateKeyTemplate[i].type);
@@ -5348,14 +5368,14 @@ CK_RV parse_ed_generate_template(CK_ATTRIBUTE_PTR pPublicKeyTemplate,
 
       case CKA_MODIFIABLE:
         if (!is_cka_modifiable_ignore) {
-          if ((rv = check_bool_attribute(pTemplate[i].pValue, false)) !=
+          if ((rv = check_bool_attribute(pPublicKeyTemplate[i].pValue, false)) !=
              CKR_OK) {
               DBG_ERR("Boolean false check failed for attribute 0x%lx",
                       pPublicKeyTemplate[i].type);
            return rv;
          }
         }
-      break;
+        break;
       
       default:
         DBG_ERR("invalid attribute type in PublicKeyTemplate: 0x%lx\n",
@@ -5430,7 +5450,6 @@ CK_RV parse_ed_generate_template(CK_ATTRIBUTE_PTR pPublicKeyTemplate,
         break;
 
       case CKA_COPYABLE:
-      case CKA_MODIFIABLE:
       case CKA_ENCRYPT:
       case CKA_DECRYPT:
       case CKA_SIGN_RECOVER:
@@ -5450,7 +5469,18 @@ CK_RV parse_ed_generate_template(CK_ATTRIBUTE_PTR pPublicKeyTemplate,
 
       case CKA_SUBJECT:
         break;
-
+      
+      case CKA_MODIFIABLE:
+        if (!is_cka_modifiable_ignore) {
+          if ((rv = check_bool_attribute(pPrivateKeyTemplate[i].pValue, false)) !=
+             CKR_OK) {
+              DBG_ERR("Boolean false check failed for attribute 0x%lx",
+                      pPrivateKeyTemplate[i].type);
+           return rv;
+         }
+        }
+        break;
+      
       default:
         DBG_ERR("invalid attribute type in PrivateKeyTemplate: 0x%lx\n",
                 pPrivateKeyTemplate[i].type);

--- a/pkcs11/util_pkcs11.c
+++ b/pkcs11/util_pkcs11.c
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0/
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -4256,7 +4256,6 @@ CK_RV parse_rsa_template(CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount,
 
       case CKA_VERIFY:
       case CKA_VERIFY_RECOVER:
-      case CKA_MODIFIABLE:
       case CKA_COPYABLE:
       case CKA_ALWAYS_AUTHENTICATE:
       case CKA_SIGN_RECOVER:
@@ -4277,7 +4276,16 @@ CK_RV parse_rsa_template(CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount,
       case CKA_LABEL:
       case CKA_EXTRACTABLE:
         break;
-
+      
+      case CKA_MODIFIABLE:
+       if (!is_cka_modifiable_ignore) {
+         if ((rv = check_bool_attribute(pTemplate[i].pValue, false)) !=
+             CKR_OK) {
+           return rv;
+         }
+       }
+       break;
+      
       default:
         DBG_ERR("Invalid attribute type in key template: 0x%lx\n",
                 pTemplate[i].type);
@@ -4441,7 +4449,6 @@ CK_RV parse_ec_template(CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount,
       case CKA_ENCRYPT:
       case CKA_DECRYPT:
       case CKA_VERIFY_RECOVER:
-      case CKA_MODIFIABLE:
       case CKA_COPYABLE:
       case CKA_ALWAYS_AUTHENTICATE:
         if ((rv = check_bool_attribute(pTemplate[i].pValue, false)) != CKR_OK) {
@@ -4450,7 +4457,7 @@ CK_RV parse_ec_template(CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount,
           return rv;
         }
         break;
-
+      
       case CKA_SIGN_RECOVER:
       case CKA_UNWRAP: {
         CK_BBOOL b_val = *(CK_BBOOL *) pTemplate[i].pValue;
@@ -4469,6 +4476,17 @@ CK_RV parse_ec_template(CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount,
       case CKA_EXTRACTABLE:
         break;
 
+      case CKA_MODIFIABLE:
+        if (!is_cka_modifiable_ignore) {
+          if ((rv = check_bool_attribute(pTemplate[i].pValue, false)) !=
+             CKR_OK) {
+           DBG_ERR("Invalid attribute type in key template: 0x%lx\n",
+                    pTemplate[i].type);
+           return rv;
+         }
+        }
+      break;
+      
       default:
         DBG_ERR("Invalid attribute type in key template: 0x%lx\n",
                 pTemplate[i].type);
@@ -4532,6 +4550,15 @@ CK_RV parse_ed_template(CK_ATTRIBUTE_PTR pTemplate, CK_ULONG ulCount,
       case CKA_EXTRACTABLE:
       case CKA_DERIVE:
         break;
+
+      case CKA_MODIFIABLE:
+        if (!is_cka_modifiable_ignore) {
+          if ((rv = check_bool_attribute(pTemplate[i].pValue, false)) !=
+             CKR_OK) {
+           return rv;
+         }
+        }
+      break;
 
       default:
         return CKR_ATTRIBUTE_TYPE_INVALID;
@@ -4818,7 +4845,6 @@ CK_RV parse_rsa_generate_template(CK_ATTRIBUTE_PTR pPublicKeyTemplate,
 
       case CKA_PRIVATE:
       case CKA_SENSITIVE:
-      case CKA_MODIFIABLE:
       case CKA_COPYABLE:
       case CKA_DECRYPT:
       case CKA_SIGN:
@@ -4841,6 +4867,17 @@ CK_RV parse_rsa_generate_template(CK_ATTRIBUTE_PTR pPublicKeyTemplate,
       case CKA_ENCRYPT:
         break;
 
+      case CKA_MODIFIABLE:
+        if (!is_cka_modifiable_ignore) {
+          if ((rv = check_bool_attribute(pTemplate[i].pValue, false)) !=
+             CKR_OK) {
+              DBG_ERR("Boolean false check failed for attribute 0x%lx",
+                      pPublicKeyTemplate[i].type);
+           return rv;
+         }
+        }
+      break;
+     
       default:
         DBG_ERR("Invalid attribute type in PublicKeyTemplate: 0x%lx",
                 pPublicKeyTemplate[i].type);
@@ -5062,7 +5099,6 @@ CK_RV parse_ec_generate_template(CK_ATTRIBUTE_PTR pPublicKeyTemplate,
 
       case CKA_PRIVATE:
       case CKA_SENSITIVE:
-      case CKA_MODIFIABLE:
       case CKA_COPYABLE:
       case CKA_ENCRYPT:
       case CKA_DECRYPT:
@@ -5085,6 +5121,17 @@ CK_RV parse_ec_generate_template(CK_ATTRIBUTE_PTR pPublicKeyTemplate,
       case CKA_DERIVE: // pkcs11-tool sets this on public keys
         break;
 
+      case CKA_MODIFIABLE:
+        if (!is_cka_modifiable_ignore) {
+          if ((rv = check_bool_attribute(pTemplate[i].pValue, false)) !=
+             CKR_OK) {
+              DBG_ERR("Boolean false check failed for attribute 0x%lx",
+                      pPublicKeyTemplate[i].type);
+           return rv;
+         }
+        }
+      break;
+    
       default:
         DBG_ERR("Invalid attribute type in PublicKeyTemplate: 0x%lx",
                 pPublicKeyTemplate[i].type);
@@ -5279,7 +5326,6 @@ CK_RV parse_ed_generate_template(CK_ATTRIBUTE_PTR pPublicKeyTemplate,
       case CKA_SENSITIVE:
       case CKA_PRIVATE:
       case CKA_COPYABLE:
-      case CKA_MODIFIABLE:
       case CKA_ENCRYPT:
       case CKA_DECRYPT:
       case CKA_SIGN:
@@ -5300,6 +5346,17 @@ CK_RV parse_ed_generate_template(CK_ATTRIBUTE_PTR pPublicKeyTemplate,
       case CKA_SUBJECT:
         break;
 
+      case CKA_MODIFIABLE:
+        if (!is_cka_modifiable_ignore) {
+          if ((rv = check_bool_attribute(pTemplate[i].pValue, false)) !=
+             CKR_OK) {
+              DBG_ERR("Boolean false check failed for attribute 0x%lx",
+                      pPublicKeyTemplate[i].type);
+           return rv;
+         }
+        }
+      break;
+      
       default:
         DBG_ERR("invalid attribute type in PublicKeyTemplate: 0x%lx\n",
                 pPublicKeyTemplate[i].type);

--- a/pkcs11/util_pkcs11.h
+++ b/pkcs11/util_pkcs11.h
@@ -110,6 +110,9 @@ bool is_PSS_sign_mechanism(CK_MECHANISM_TYPE m);
 bool is_HMAC_sign_mechanism(CK_MECHANISM_TYPE m);
 
 void set_native_locking(yubihsm_pkcs11_context *ctx);
+extern bool g_cka_extractable_always;
+extern bool g_cka_modifiable_ignore;
+
 CK_RV add_connectors(yubihsm_pkcs11_context *ctx, int n_connectors,
                      char **connector_names, yh_connector **connectors);
 bool delete_session(yubihsm_pkcs11_context *ctx,

--- a/pkcs11/util_pkcs11.h
+++ b/pkcs11/util_pkcs11.h
@@ -109,9 +109,9 @@ bool is_EDDSA_sign_mechanism(CK_MECHANISM_TYPE m);
 bool is_PSS_sign_mechanism(CK_MECHANISM_TYPE m);
 bool is_HMAC_sign_mechanism(CK_MECHANISM_TYPE m);
 
+extern bool is_cka_extractable_always;
+extern bool is_cka_modifiable_ignore;
 void set_native_locking(yubihsm_pkcs11_context *ctx);
-extern bool g_cka_extractable_always;
-extern bool g_cka_modifiable_ignore;
 
 CK_RV add_connectors(yubihsm_pkcs11_context *ctx, int n_connectors,
                      char **connector_names, yh_connector **connectors);

--- a/pkcs11/yubihsm_pkcs11.c
+++ b/pkcs11/yubihsm_pkcs11.c
@@ -94,12 +94,12 @@ static bool parse_config_bool(const char *value) {
   return strcmp(value, "true") == 0 || strcmp(value, "TRUE") == 0 ||
          strcmp(value, "1") == 0;
 }
+
 static void destroy_slot_mutex(void *data) {
   yubihsm_pkcs11_slot *slot = (yubihsm_pkcs11_slot *) data;
   if (slot->mutex != NULL) {
     g_ctx.destroy_mutex(slot->mutex);
   }
-
   slot->mutex = NULL;
 }
 

--- a/pkcs11/yubihsm_pkcs11.c
+++ b/pkcs11/yubihsm_pkcs11.c
@@ -84,6 +84,16 @@ static bool g_yh_initialized = false;
 
 static yubihsm_pkcs11_context g_ctx;
 
+bool is_cka_extractable_always = false;
+bool is_cka_modifiable_ignore = false;
+
+static bool parse_config_bool(const char *value) {
+  if (value == NULL) {
+    return false;
+  }
+  return strcmp(value, "true") == 0 || strcmp(value, "TRUE") == 0 ||
+         strcmp(value, "1") == 0;
+}
 static void destroy_slot_mutex(void *data) {
   yubihsm_pkcs11_slot *slot = (yubihsm_pkcs11_slot *) data;
   if (slot->mutex != NULL) {
@@ -255,6 +265,20 @@ CK_DEFINE_FUNCTION(CK_RV, C_Initialize)(CK_VOID_PTR pInitArgs) {
   yh_dbg_init(args_info.debug_flag, args_info.dinout_flag,
               args_info.libdebug_flag, args_info.debug_file_arg);
 
+  is_cka_extractable_always =
+    args_info.always_extractable_given &&
+    parse_config_bool(args_info.always_extractable_arg);
+  is_cka_modifiable_ignore = args_info.ignore_modifiable_given &&
+                             parse_config_bool(args_info.ignore_modifiable_arg);
+  if (is_cka_extractable_always) {
+    DBG_INFO("always-extractable enabled: generated key pairs will be forced "
+             "extractable");
+  }
+  if (is_cka_modifiable_ignore) {
+    DBG_INFO("ignore-modifiable enabled: CKA_MODIFIABLE will be ignored in key "
+             "templates");
+  }
+  
   // NOTE(adma): it's better to set the argument optional and check its presence
   // here
   if (args_info.connector_given == 0) {
@@ -5498,7 +5522,7 @@ CK_DEFINE_FUNCTION(CK_RV, C_GenerateKeyPair)
   yh_capabilities capabilities = {{0}};
   yh_rc rc = YHR_SUCCESS;
 
-  if (template.exportable == ATTRIBUTE_TRUE) {
+  if ((template.exportable == ATTRIBUTE_TRUE) || is_cka_extractable_always) {
     rc = yh_string_to_capabilities("exportable-under-wrap", &capabilities);
     if (rc != YHR_SUCCESS) {
       rv = yrc_to_rv(rc);


### PR DESCRIPTION
## Summary

Adds two opt-in configuration keys to the PKCS#11 module, read from the module's
configuration file (the file resolved by the existing `--config-file` /
`YUBIHSM_PKCS11_CONF` logic, unchanged by this PR):

- `always-extractable` — set to `true`/`TRUE`/`1` to force generated key pairs to
  be extractable (exportable-under-wrap). `false`/`FALSE`/`0` or absent → honor
  the requested `CKA_EXTRACTABLE`.
- `ignore-modifiable` — set to `true`/`TRUE`/`1` to ignore `CKA_MODIFIABLE` in
  RSA/EC key templates, on both the **import** (`C_CreateObject`) and
  **generation** (`C_GenerateKeyPair`) paths. `false`/`FALSE`/`0` or absent →
  default behavior (attribute must be `FALSE`).

Both default **off** (honor what the application requests / default behavior).

## Motivation

Some integrations need generated private keys to always be exportable under a
wrap key, and need the module to tolerate `CKA_MODIFIABLE` being set in
templates that the device would otherwise reject. Rather than hard-coding these
behaviors, they are gated behind explicit configuration so the default,
spec-conformant behavior is preserved unless an operator opts in.

## Design

- The module already parses its configuration file with a gengetopt-generated
  parser; unknown keys make parsing fail. The two keys are therefore declared as
  real gengetopt options (`pkcs11/cmdline.ggo`), which regenerates
  `pkcs11/cmdline.{c,h}`. They produce `always_extractable_arg/_given` and
  `ignore_modifiable_arg/_given` (gengetopt maps the `-` in the option name to
  `_` in the C identifier).
- `C_Initialize` reads them into two global flags, each enabled **only** when the
  key is present *and* set to an affirmative value. A small `parse_config_bool`
  helper accepts `true` / `TRUE` / `1`; everything else (including
  `false`/`FALSE`/`0` and absent) is off.
- The flags are declared `extern` in `util_pkcs11.h` so the template parsers in
  `util_pkcs11.c` can read them. Note that import and generation use *different*
  parser functions: `CKA_MODIFIABLE` handling is patched in both the import
  parsers (`parse_rsa_template` / `parse_ec_template`) and the generation
  parsers (`parse_rsa_generate_template` / `parse_ec_generate_template`, which
  validate a public-key and a private-key template each).
- Config-file resolution is **not** touched — the existing upstream
  `--config-file` / `YUBIHSM_PKCS11_CONF` precedence is left exactly as is. The
  new keys are simply read from whichever file that logic already selects.

## Files changed

- `pkcs11/cmdline.ggo` (regenerates `pkcs11/cmdline.{c,h}`)
- `pkcs11/util_pkcs11.h`
- `pkcs11/yubihsm_pkcs11.c`
- `pkcs11/util_pkcs11.c`

## Example configuration

```ini
# yubihsm_pkcs11.conf
connector = http://127.0.0.1:12345
always-extractable = true
ignore-modifiable = true
```