### PR TITLE
Open `--out=<file>` in overwrite mode, not append

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1466,7 +1466,7 @@ static FILE *open_file(const char *name, bool input) {
     if (strcmp(name, "-") == 0) {
       return stdout;
     } else {
-      return fopen(name, "ab");
+      return fopen(name, "wb");
     }
   }
 }


### PR DESCRIPTION
## Summary

Output files selected with `--out=<file>` are now opened in **overwrite
(truncate)** mode instead of **append** mode, so exporting to an existing file
produces a single, valid, re-importable object.

## Problem

For `yubihsm-shell` actions that write a result to a file (e.g. `get-wrapped`,
`get-public-key`, `sign-*`, …), `--out=<file>` opened the file in **append**
mode. Exporting the same key twice to the same filename left **two concatenated
exports** in the file, which can no longer be re-imported:

```
$ yubihsm-shell ... --action get-wrapped --out wrapped.bin   # first export
$ yubihsm-shell ... --action get-wrapped --out wrapped.bin   # appended again
$ wc -c wrapped.bin                                          # ~2x expected size
```

## Root cause

All output files are opened through a single helper, `open_file()` in
`src/main.c`. Its output branch used `fopen(name, "ab")` (append + binary). The
default output is **STDOUT** (`name == "-"` returns `stdout` directly and never
reaches `fopen`), for which append vs. truncate is irrelevant — which is likely
why append mode went unnoticed.

## Solution

Change the single output `fopen` from `"ab"` to `"wb"` (write/truncate +
binary). Because `open_file(..., false)` is the **only** output-file open in the
codebase (both the `--out` startup path and the interactive `set out <file>`
command funnel through it), this one change fixes every action's `--out`
handling. The STDOUT path is unchanged.

Verified there is no other append-mode file open anywhere in `src/` or `lib/`.

## Files changed

- `src/main.c`